### PR TITLE
Add ability to disable comment edits and deletes

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ class Project extends Model implements Commentable
 
 ### Usage with Filament
 
-You are free to register the plugin in your Panel(s); however, there is currently no configuration required or supported at the Panel level although it is a good habit:
+You can register the plugin in your Panel(s) and configure editing and deleting permissions:
 
 ```php
 use Kirschbaum\Commentions\CommentionsPlugin;
@@ -57,6 +57,8 @@ use Kirschbaum\Commentions\CommentionsPlugin;
 return $panel
     ->plugins([
         CommentionsPlugin::make()
+            ->disallowEdits()    // Prevent users from editing their comments
+            ->disallowDeletes()  // Prevent users from deleting their comments
     ])
 ```
 
@@ -107,6 +109,37 @@ If your `User` model lives in a different namespace than `App\Models\User`, you 
         'model' => \App\Domains\Users\User::class,
     ],
 ```
+
+### Disabling comment editing and deletion
+
+By default, users can edit and delete their own comments. You can disable this functionality in two ways:
+
+#### 1. Using the plugin configuration
+
+```php
+use Kirschbaum\Commentions\CommentionsPlugin;
+
+return $panel
+    ->plugins([
+        CommentionsPlugin::make()
+            ->disallowEdits()    // Prevent users from editing their comments
+            ->disallowDeletes()  // Prevent users from deleting their comments
+    ])
+```
+
+#### 2. Using the configuration file
+
+Set the `allow_edits` and `allow_deletes` options in your `config/commentions.php` file:
+
+```php
+    /**
+     * Comment editing/deleting options.
+     */
+    'allow_edits' => false,
+    'allow_deletes' => false,
+```
+
+> **Note:** The plugin configuration takes precedence over the config file settings.
 
 By default, the `name` property will be used to render the mention names. You can customize it either by implementing the Filament `HasName` interface OR by implementing the optional `getCommenterName` method.
 

--- a/config/commentions.php
+++ b/config/commentions.php
@@ -12,4 +12,10 @@ return [
     'commenter' => [
         'model' => \App\Models\User::class,
     ],
+
+    /**
+     * Comment editing/deleting options.
+     */
+    'allow_edits' => true,
+    'allow_deletes' => true,
 ];

--- a/src/Comment.php
+++ b/src/Comment.php
@@ -153,12 +153,12 @@ class Comment extends Model implements RenderableComment
 
     public function canEdit(): bool
     {
-        return $this->isAuthor(Config::resolveAuthenticatedUser());
+        return Config::allowEdits() && $this->isAuthor(Config::resolveAuthenticatedUser());
     }
 
     public function canDelete(): bool
     {
-        return $this->canEdit();
+        return Config::allowDeletes() && $this->isAuthor(Config::resolveAuthenticatedUser());
     }
 
     public function getLabel(): ?string

--- a/src/CommentionsPlugin.php
+++ b/src/CommentionsPlugin.php
@@ -7,12 +7,20 @@ use Filament\Panel;
 
 class CommentionsPlugin implements Plugin
 {
+    protected bool $allowEdits = true;
+    
+    protected bool $allowDeletes = true;
+
     public function getId(): string
     {
         return CommentionsServiceProvider::$name;
     }
 
-    public function register(Panel $panel): void {}
+    public function register(Panel $panel): void 
+    {
+        Config::allowEdits($this->allowEdits);
+        Config::allowDeletes($this->allowDeletes);
+    }
 
     public function boot(Panel $panel): void {}
 
@@ -24,5 +32,19 @@ class CommentionsPlugin implements Plugin
     public static function get(): static
     {
         return filament(app(static::class)->getId());
+    }
+    
+    public function disallowEdits(): static
+    {
+        $this->allowEdits = false;
+        
+        return $this;
+    }
+    
+    public function disallowDeletes(): static
+    {
+        $this->allowDeletes = false;
+        
+        return $this;
     }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -11,6 +11,10 @@ class Config
 
     protected static ?Closure $resolveAuthenticatedUser = null;
 
+    protected static ?bool $allowEdits = null;
+
+    protected static ?bool $allowDeletes = null;
+
     public static function resolveAuthenticatedUserUsing(Closure $callback): void
     {
         static::$resolveAuthenticatedUser = $callback;
@@ -26,5 +30,25 @@ class Config
     public static function getCommenterModel(): string
     {
         return config('commentions.commenter.model');
+    }
+
+    public static function allowEdits(?bool $allow = null): bool|null
+    {
+        if (is_bool($allow)) {
+            static::$allowEdits = $allow;
+            return null;
+        }
+        
+        return static::$allowEdits ?? config('commentions.allow_edits', true);
+    }
+
+    public static function allowDeletes(?bool $allow = null): bool|null
+    {
+        if (is_bool($allow)) {
+            static::$allowDeletes = $allow;
+            return null;
+        }
+        
+        return static::$allowDeletes ?? config('commentions.allow_deletes', true);
     }
 }

--- a/src/Livewire/Comment.php
+++ b/src/Livewire/Comment.php
@@ -30,7 +30,7 @@ class Comment extends Component
     #[Renderless]
     public function delete()
     {
-        if (! $this->comment->isAuthor(Config::resolveAuthenticatedUser())) {
+        if (! $this->comment->canDelete()) {
             return;
         }
 
@@ -67,7 +67,7 @@ class Comment extends Component
 
     public function edit(): void
     {
-        if (! $this->comment->isAuthor(Config::resolveAuthenticatedUser())) {
+        if (! $this->comment->canEdit()) {
             return;
         }
 
@@ -79,7 +79,7 @@ class Comment extends Component
 
     public function updateComment()
     {
-        if (! $this->comment->isAuthor(Config::resolveAuthenticatedUser())) {
+        if (! $this->comment->canEdit()) {
             return;
         }
 

--- a/tests/CommentTest.php
+++ b/tests/CommentTest.php
@@ -4,6 +4,8 @@ namespace Tests;
 
 use Illuminate\Support\Facades\Event;
 use Kirschbaum\Commentions\Comment;
+use Kirschbaum\Commentions\CommentionsPlugin;
+use Kirschbaum\Commentions\Config;
 use Kirschbaum\Commentions\Events\UserWasMentionedEvent;
 use Tests\Models\Post;
 use Tests\Models\User;
@@ -67,4 +69,84 @@ test('it can get mentioned user ids from comment', function () {
         ->toHaveCount(2)
         ->toContain($mentionedUser1)
         ->toContain($mentionedUser2);
+});
+
+test('it can disable editing of comments', function () {
+    $user = User::factory()->create();
+    $post = Post::factory()->create();
+    $comment = $post->comment('This is a test comment', $user);
+
+    // Set authenticated user to the comment author
+    Config::resolveAuthenticatedUserUsing(fn () => $user);
+
+    // Should be able to edit by default
+    expect($comment->canEdit())->toBeTrue();
+
+    // Disable edits
+    config(['commentions.allow_edits' => false]);
+    expect($comment->canEdit())->toBeFalse();
+});
+
+test('it can disable deletion of comments', function () {
+    $user = User::factory()->create();
+    $post = Post::factory()->create();
+    $comment = $post->comment('This is a test comment', $user);
+
+    // Set authenticated user to the comment author
+    Config::resolveAuthenticatedUserUsing(fn () => $user);
+
+    // Should be able to delete by default
+    expect($comment->canDelete())->toBeTrue();
+
+    // Disable deletes
+    config(['commentions.allow_deletes' => false]);
+    expect($comment->canDelete())->toBeFalse();
+});
+
+test('plugin can disallow edits and deletes', function () {
+    $user = User::factory()->create();
+    $post = Post::factory()->create();
+    $comment = $post->comment('This is a test comment', $user);
+
+    // Set authenticated user to the comment author
+    Config::resolveAuthenticatedUserUsing(fn () => $user);
+
+    // Reset to default values
+    Config::allowEdits(true);
+    Config::allowDeletes(true);
+
+    // Should be able to edit and delete by default
+    expect($comment->canEdit())->toBeTrue();
+    expect($comment->canDelete())->toBeTrue();
+
+    // Create a plugin instance and disallow edits
+    $plugin = new CommentionsPlugin();
+    $plugin->disallowEdits();
+    $panel = new \Filament\Panel();
+    $plugin->register($panel);
+
+    expect($comment->canEdit())->toBeFalse();
+    expect($comment->canDelete())->toBeTrue();
+
+    // Reset and test disallowing deletes
+    Config::allowEdits(true);
+    Config::allowDeletes(true);
+
+    $plugin = new CommentionsPlugin();
+    $plugin->disallowDeletes();
+    $plugin->register($panel);
+
+    expect($comment->canEdit())->toBeTrue();
+    expect($comment->canDelete())->toBeFalse();
+
+    // Test disallowing both
+    Config::allowEdits(true);
+    Config::allowDeletes(true);
+
+    $plugin = new CommentionsPlugin();
+    $plugin->disallowEdits()->disallowDeletes();
+    $plugin->register($panel);
+
+    expect($comment->canEdit())->toBeFalse();
+    expect($comment->canDelete())->toBeFalse();
 });


### PR DESCRIPTION
## Summary
- Added config options to disable comment editing and deletion
- Added plugin configuration methods disallowEdits() and disallowDeletes()
- Updated Comment.php to respect these settings
- Includes tests and documentation updates

## Test plan
- Run all tests: `./vendor/bin/pest`
- Verify functionality by creating a new plugin with `disallowEdits()` and `disallowDeletes()` in a Laravel application

🤖 Generated with [Claude Code](https://claude.ai/code)