### PR TITLE
Increase Larastan Level

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,7 +9,7 @@ parameters:
         - tests/
 
     # Level 10 is the highest level
-    level: 0
+    level: 1
 
     ignoreErrors:
         -
@@ -47,3 +47,15 @@ parameters:
             identifier: variable.undefined
             count: 3
             path: tests/Pest.php
+
+        -
+            message: '#^Call to an undefined method PHPUnit\\Framework\\TestCase\:\:assertDatabaseHas\(\)\.$#'
+            identifier: method.notFound
+            count: 2
+            path: tests/Livewire/CommentReactionTest.php
+
+        -
+            message: '#^Call to an undefined method PHPUnit\\Framework\\TestCase\:\:assertDatabaseMissing\(\)\.$#'
+            identifier: method.notFound
+            count: 3
+            path: tests/Livewire/CommentReactionTest.php

--- a/src/Actions/ToggleCommentReaction.php
+++ b/src/Actions/ToggleCommentReaction.php
@@ -2,9 +2,9 @@
 
 namespace Kirschbaum\Commentions\Actions;
 
-use Kirschbaum\Commentions\Config;
 use Kirschbaum\Commentions\Comment;
 use Kirschbaum\Commentions\CommentReaction;
+use Kirschbaum\Commentions\Config;
 use Kirschbaum\Commentions\Contracts\Commenter;
 use Kirschbaum\Commentions\Events\CommentWasReactedEvent;
 

--- a/src/Comment.php
+++ b/src/Comment.php
@@ -2,7 +2,9 @@
 
 namespace Kirschbaum\Commentions;
 
+use Carbon\Carbon;
 use Closure;
+use DateTime;
 use Filament\Models\Contracts\HasAvatar;
 use Filament\Support\Facades\FilamentColor;
 use Illuminate\Database\Eloquent\Casts\Attribute;
@@ -25,8 +27,11 @@ use Spatie\Color\Rgb;
  * @property string $body
  * @property string $body_markdown
  * @property string $body_parsed
+ * @property int $author_id
  * @property Model|Commenter $author
  * @property Commentable $commentable
+ * @property-read DateTime|Carbon $created_at
+ * @property-read DateTime|Carbon $updated_at
  */
 class Comment extends Model implements RenderableComment
 {
@@ -143,12 +148,12 @@ class Comment extends Model implements RenderableComment
         return $this->body_parsed;
     }
 
-    public function getCreatedAt(): \DateTime|\Carbon\Carbon
+    public function getCreatedAt(): DateTime|Carbon
     {
         return $this->created_at;
     }
 
-    public function getUpdatedAt(): \DateTime|\Carbon\Carbon
+    public function getUpdatedAt(): DateTime|Carbon
     {
         return $this->updated_at;
     }

--- a/src/CommentReaction.php
+++ b/src/CommentReaction.php
@@ -3,9 +3,9 @@
 namespace Kirschbaum\Commentions;
 
 use Illuminate\Database\Eloquent\Model;
-use Kirschbaum\Commentions\Contracts\Commenter;
-use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Kirschbaum\Commentions\Contracts\Commenter;
 
 /**
  * @property-read Comment $comment

--- a/src/CommentionsServiceProvider.php
+++ b/src/CommentionsServiceProvider.php
@@ -2,15 +2,15 @@
 
 namespace Kirschbaum\Commentions;
 
-use Livewire\Livewire;
-use Filament\Support\Assets\Js;
 use Filament\Support\Assets\Css;
-use Spatie\LaravelPackageTools\Package;
+use Filament\Support\Assets\Js;
 use Filament\Support\Facades\FilamentAsset;
 use Kirschbaum\Commentions\Livewire\Comment;
-use Kirschbaum\Commentions\Livewire\Reactions;
-use Kirschbaum\Commentions\Livewire\Comments;
 use Kirschbaum\Commentions\Livewire\CommentList;
+use Kirschbaum\Commentions\Livewire\Comments;
+use Kirschbaum\Commentions\Livewire\Reactions;
+use Livewire\Livewire;
+use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 
 class CommentionsServiceProvider extends PackageServiceProvider

--- a/src/Events/CommentWasReactedEvent.php
+++ b/src/Events/CommentWasReactedEvent.php
@@ -6,15 +6,14 @@ use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 use Kirschbaum\Commentions\Comment;
 use Kirschbaum\Commentions\CommentReaction;
-use Kirschbaum\Commentions\Contracts\Commenter;
 
 class CommentWasReactedEvent
 {
-    use Dispatchable, SerializesModels;
+    use Dispatchable;
+    use SerializesModels;
 
     public function __construct(
         public Comment $comment,
         public CommentReaction $reaction,
-    ) {
-    }
+    ) {}
 }

--- a/src/Livewire/Comment.php
+++ b/src/Livewire/Comment.php
@@ -3,16 +3,13 @@
 namespace Kirschbaum\Commentions\Livewire;
 
 use Filament\Notifications\Notification;
-use Illuminate\Support\Facades\Log;
+use Illuminate\Contracts\View\View;
 use Kirschbaum\Commentions\Comment as CommentModel;
 use Kirschbaum\Commentions\Contracts\RenderableComment;
 use Kirschbaum\Commentions\Livewire\Concerns\HasMentions;
-use Livewire\Attributes\Computed;
 use Livewire\Attributes\On;
 use Livewire\Attributes\Renderless;
-use Livewire\Attributes\Locked;
 use Livewire\Component;
-use Illuminate\Contracts\View\View;
 
 class Comment extends Component
 {

--- a/src/Livewire/Reactions.php
+++ b/src/Livewire/Reactions.php
@@ -2,13 +2,13 @@
 
 namespace Kirschbaum\Commentions\Livewire;
 
-use Livewire\Component;
-use Livewire\Attributes\On;
-use Livewire\Attributes\Computed;
-use Kirschbaum\Commentions\Config;
 use Illuminate\Contracts\View\View;
 use Kirschbaum\Commentions\Comment as CommentModel;
+use Kirschbaum\Commentions\Config;
 use Kirschbaum\Commentions\Contracts\RenderableComment;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\On;
+use Livewire\Component;
 
 class Reactions extends Component
 {

--- a/src/RenderableComment.php
+++ b/src/RenderableComment.php
@@ -51,7 +51,7 @@ class RenderableComment implements RenderableCommentContract, Wireable
         $this->body = $body;
         $this->parsedBody = $parsedBody;
         $this->createdAt = $createdAt;
-        $this->updatedAt = $updatedAt ?? $createdAt;
+        $this->updatedAt = $updatedAt;
         $this->canEdit = $canEdit;
         $this->canDelete = $canDelete;
         $this->label = $label;

--- a/tests/Livewire/CommentReactionTest.php
+++ b/tests/Livewire/CommentReactionTest.php
@@ -32,7 +32,7 @@ test('user can add configured reactions to a comment', function (string $reactio
     livewire(CommentComponent::class, ['comment' => $comment])
         ->call('toggleReaction', $reactionEmoji);
 
-    Event::assertDispatched(CommentWasReactedEvent::class, function (CommentWasReactedEvent $event) use ($comment, $user, $reactionEmoji) {
+    Event::assertDispatched(CommentWasReactedEvent::class, function (CommentWasReactedEvent $event) use ($comment, $reactionEmoji) {
         return $event->comment->is($comment)
             && $event->reaction !== null
             && $event->reaction->reaction === $reactionEmoji;
@@ -137,9 +137,9 @@ test('reaction summary handles multiple different reactions', function () {
 
     // Check Blade rendering simulation (simplified)
     $component
-        ->assertSeeHtml('wire:key="inline-reaction-button-👍-'.$comment->getId().'"') // Count exists for 👍
+        ->assertSeeHtml('wire:key="inline-reaction-button-👍-' . $comment->getId() . '"') // Count exists for 👍
         ->assertSeeHtml('>2</span>') // Correct count for 👍
-        ->assertSeeHtml('wire:key="inline-reaction-button-❤️-'.$comment->getId().'"') // Count exists for ❤️
+        ->assertSeeHtml('wire:key="inline-reaction-button-❤️-' . $comment->getId() . '"') // Count exists for ❤️
         ->assertSeeHtml('>1</span>'); // Correct count for ❤️
 });
 


### PR DESCRIPTION
The Larastan level was set to 0 in the initial PR. There was also another PR that got merged before the CI pipeline was that is causing some violations on the main branch, so this PR fixes those and bumps up to Larastan level 1 as the baseline level.