### PR TITLE
Use comment content hash as key

### DIFF
--- a/resources/views/comment-list.blade.php
+++ b/resources/views/comment-list.blade.php
@@ -16,7 +16,7 @@
 
     @foreach ($this->comments as $comment)
         <livewire:commentions::comment
-            :key="'comment-' . $comment->getId()"
+            :key="$comment->getContentHash()"
             :comment="$comment"
             :mentionables="$mentionables"
         />

--- a/src/Comment.php
+++ b/src/Comment.php
@@ -173,6 +173,14 @@ class Comment extends Model implements RenderableComment
         return null;
     }
 
+    public function getContentHash(): string
+    {
+        return md5(json_encode([
+            'body' => $this->body,
+            'reactions' => $this->reactions->pluck('id'),
+        ]));
+    }
+
     protected static function newFactory()
     {
         return CommentFactory::new();

--- a/src/Contracts/RenderableComment.php
+++ b/src/Contracts/RenderableComment.php
@@ -21,4 +21,6 @@ interface RenderableComment
     public function getUpdatedAt(): \DateTime|\Carbon\Carbon;
 
     public function getLabel(): ?string;
+
+    public function getContentHash(): string;
 }

--- a/src/RenderableComment.php
+++ b/src/RenderableComment.php
@@ -94,6 +94,11 @@ class RenderableComment implements RenderableCommentContract, Wireable
         return $this->label;
     }
 
+    public function getContentHash(): string
+    {
+        return "comment-$this->id";
+    }
+
     public function toLivewire()
     {
         return [


### PR DESCRIPTION
Currently, the `comment-list` polls for changes, but because Livewire is not reactive, it is only rendering new comments (or stops rendering deleted comments). Any comment that is edited or has new reactions doesn't display changes after the polling because the comment child element does not re-render due to the key not changing.

This PR has comments generate a hash made of the body content and an array of reaction's IDs. This way whenever the body or reactions change it will cause the comment element to re-render and display the new content.

This should resolve the remaining concerns in #9  