### PR TITLE
ISSUE-37: Fix Filament 4 Namespace in Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,27 @@ There are a couple of ways to use Commentions with Filament.
 > This works for Filament 3 and 4.
 
 ```php
-Infolists\Components\Section::make('Comments')
+    CommentsEntry::make('comments')
+        ->mentionables(fn (Model $record) => User::all()),
+```
+
+If you wish to make the comments more distinct from the rest of the page, we recommend wrapping them in a `Section`.
+
+For Filament 3:
+
+```php
+\Filament\Infolists\Components\Section::make('Comments')
     ->schema([
-        CommentsEntry::make('comments')
-            ->mentionables(fn (Model $record) => User::all()),
+        CommentsEntry::make('comments'),
+    ]),
+```
+
+For Filament 4:
+
+```php
+\Filament\Schemas\Components\Section::make('Comments')
+    ->components([
+        CommentsEntry::make('comments'),
     ]),
 ```
 


### PR DESCRIPTION
As pointed out in #37 the usage of a Filament 3 `Section` component that has been moved in Filament 4 is incorrectly labeled as "works in Filament 3 _and 4_". This adjusts the docs to make the usage of the surrounding section a recommendation instead and has the correct namespaces for both versions.