### PR TITLE
ISSUE-39: Pass entry to Filament entry-wrapper-view

### DIFF
--- a/resources/views/filament/infolists/components/comments-entry.blade.php
+++ b/resources/views/filament/infolists/components/comments-entry.blade.php
@@ -1,4 +1,4 @@
-<x-dynamic-component :component="$getEntryWrapperView()">
+<x-dynamic-component :component="$getEntryWrapperView()" :entry="$entry">
     <livewire:commentions::comments
         :record="$getRecord()"
         :mentionables="$getMentionables()"


### PR DESCRIPTION
In Filament v4.0.0-beta20 the `entry-wrapper-view` component was updated and caused our Comments component to start failing as it uses the wrapper view but doesn't pass an entry. This PR passes it along, fixing #39, and still works in Filament 3 making this a non-breaking change.