### PR TITLE
feat: add Spanish translations for Filament Comments plugin

### DIFF
--- a/resources/lang/es/comments.php
+++ b/resources/lang/es/comments.php
@@ -1,0 +1,21 @@
+<?php
+
+return [
+    'label' => 'Comentarios',
+    'no_comments_yet' => 'Aún no hay comentarios.',
+
+    'user_avatar_alt' => 'Avatar de usuario',
+
+    'commented_at' => 'Comentado el :datetime',
+    'edited_at' => 'Editado el :datetime',
+    'edited' => 'editado',
+
+    'delete_comment_heading' => 'Eliminar comentario',
+    'delete_comment_body' => '¿Seguro que deseas eliminar este comentario? Esta acción no se puede deshacer.',
+
+    'cancel' => 'Cancelar',
+    'delete' => 'Eliminar',
+    'save' => 'Guardar',
+    'comment' => 'Comentar',
+    'add_reaction' => 'Agregar reacción',
+];


### PR DESCRIPTION
Adds full Spanish translations for the Comments plugin.

- Created `resources/lang/es/comments.php`
- All strings translated, keeping placeholders like :datetime

This will help Spanish-speaking users have the plugin fully localized.
