### PR TITLE
Refactor notification titles to use translation strings

### DIFF
--- a/resources/lang/en/comments.php
+++ b/resources/lang/en/comments.php
@@ -12,6 +12,7 @@ return [
 
     'delete_comment_heading' => 'Delete Comment',
     'delete_comment_body' => 'Are you sure you want to delete this comment? This action cannot be undone.',
+    'comment_deleted' => 'Comment deleted',
 
     'cancel' => 'Cancel',
     'delete' => 'Delete',
@@ -21,7 +22,9 @@ return [
 
     'notifications' => 'Notifications',
     'unsubscribe' => 'Unsubscribe',
+    'unsubscribed_notification_title' => 'Unsubscribed from notifications',
     'subscribe' => 'Subscribe',
+    'subscribed_notification_title' => 'Subscribed to notifications',
     'subscribers' => 'Subscribers',
     'more' => 'more',
 ];

--- a/src/Filament/Actions/SubscriptionAction.php
+++ b/src/Filament/Actions/SubscriptionAction.php
@@ -26,7 +26,7 @@ class SubscriptionAction extends Action
                 }
 
                 $this->successNotificationTitle(
-                    $subscribed ? 'Subscribed to notifications' : 'Unsubscribed from notifications'
+                    $subscribed ? __('commentions::comments.subscribed_notification_title') : __('commentions::comments.unsubscribed_notification_title')
                 );
 
                 $this->success();

--- a/src/Filament/Concerns/HasSidebar.php
+++ b/src/Filament/Concerns/HasSidebar.php
@@ -112,14 +112,14 @@ trait HasSidebar
         $user = $this->resolveCurrentUser();
 
         if (! $user) {
-            return $this->evaluateSubscriptionOverride($this->subscribeLabelOverride, $record) ?? 'Subscribe';
+            return $this->evaluateSubscriptionOverride($this->subscribeLabelOverride, $record) ?? __('commentions::comments.subscribe');
         }
 
         if ($record->isSubscribed($user)) {
-            return $this->evaluateSubscriptionOverride($this->unsubscribeLabelOverride, $record) ?? 'Unsubscribe';
+            return $this->evaluateSubscriptionOverride($this->unsubscribeLabelOverride, $record) ?? __('commentions::comments.unsubscribe');
         }
 
-        return $this->evaluateSubscriptionOverride($this->subscribeLabelOverride, $record) ?? 'Subscribe';
+        return $this->evaluateSubscriptionOverride($this->subscribeLabelOverride, $record) ?? __('commentions::comments.subscribe');
     }
 
     protected function computeSubscriptionIcon(Model $record): string

--- a/src/Livewire/Comment.php
+++ b/src/Livewire/Comment.php
@@ -48,7 +48,7 @@ class Comment extends Component
         $this->dispatch('comment:deleted');
 
         Notification::make()
-            ->title('Comment deleted')
+            ->title(__('commentions::comments.comment_deleted'))
             ->success()
             ->send();
     }

--- a/src/Livewire/Concerns/HasSidebar.php
+++ b/src/Livewire/Concerns/HasSidebar.php
@@ -80,14 +80,14 @@ trait HasSidebar
             $this->record->unsubscribe($user);
 
             Notification::make()
-                ->title('Unsubscribed from notifications')
+                ->title(__('commentions::comments.unsubscribed_notification_title'))
                 ->success()
                 ->send();
         } else {
             $this->record->subscribe($user);
 
             Notification::make()
-                ->title('Subscribed to notifications')
+                ->title(__('commentions::comments.subscribed_notification_title'))
                 ->success()
                 ->send();
         }


### PR DESCRIPTION
Noticed these were not translated yet.

Also some strings in the javascript are still hardcoded english, do you want those translated?