### PR TITLE
fix: update missing subscription table config

### DIFF
--- a/src/CommentSubscription.php
+++ b/src/CommentSubscription.php
@@ -18,6 +18,11 @@ class CommentSubscription extends Model
         'subscriber_type',
     ];
 
+    public function getTable()
+    {
+        return Config::getCommentSubscriptionTable();
+    }
+
     public function subscribable(): MorphTo
     {
         return $this->morphTo();

--- a/src/Config.php
+++ b/src/Config.php
@@ -41,6 +41,11 @@ class Config
         return config('commentions.tables.comment_reactions', 'comment_reactions');
     }
 
+    public static function getCommentSubscriptionTable(): string
+    {
+        return config('commentions.tables.comment_subscriptions', 'comment_subscriptions');
+    }
+
     public static function resolveCommentUrlUsing(Closure $callback): void
     {
         static::$resolveCommentUrl = $callback;


### PR DESCRIPTION
To permit to install with customs names tables, subscription table case was missing.
Fixed it in this PR