### PR TITLE
Fix "Snapshot missing" errors caused by unstable Livewire keys in the comment list

### DIFF
--- a/resources/views/comment-list.blade.php
+++ b/resources/views/comment-list.blade.php
@@ -17,7 +17,7 @@
     @foreach ($this->comments as $comment)
         <livewire:dynamic-component
             :component="$commentionsComponentPrefix . 'comment'"
-            :key="$comment->getId()"
+            :key="$comment::class . ':' . $comment->getId()"
             :comment="$comment"
             :mentionables="$mentionables"
             :tip-tap-css-classes="$tipTapCssClasses"

--- a/resources/views/comment-list.blade.php
+++ b/resources/views/comment-list.blade.php
@@ -17,7 +17,7 @@
     @foreach ($this->comments as $comment)
         <livewire:dynamic-component
             :component="$commentionsComponentPrefix . 'comment'"
-            :key="$comment->getContentHash()"
+            :key="$comment->getId()"
             :comment="$comment"
             :mentionables="$mentionables"
             :tip-tap-css-classes="$tipTapCssClasses"

--- a/src/Comment.php
+++ b/src/Comment.php
@@ -175,6 +175,9 @@ class Comment extends Model implements RenderableComment
         return null;
     }
 
+    /**
+     * @deprecated No longer used internally for Livewire keys; will be removed in the next major version.
+     */
     public function getContentHash(): string
     {
         return md5(json_encode([

--- a/src/Contracts/RenderableComment.php
+++ b/src/Contracts/RenderableComment.php
@@ -24,5 +24,8 @@ interface RenderableComment
 
     public function getLabel(): ?string;
 
+    /**
+     * @deprecated No longer used internally for Livewire keys; will be removed in the next major version.
+     */
     public function getContentHash(): string;
 }

--- a/src/RenderableComment.php
+++ b/src/RenderableComment.php
@@ -95,6 +95,9 @@ class RenderableComment implements RenderableCommentContract, Wireable
         return $this->label;
     }
 
+    /**
+     * @deprecated No longer used internally for Livewire keys; will be removed in the next major version.
+     */
     public function getContentHash(): string
     {
         return "comment-$this->id";

--- a/tests/Livewire/CommentListTest.php
+++ b/tests/Livewire/CommentListTest.php
@@ -3,14 +3,24 @@
 use Kirschbaum\Commentions\Comment as CommentModel;
 use Kirschbaum\Commentions\Livewire\CommentList;
 use Kirschbaum\Commentions\RenderableComment;
-use Mockery;
+use Mockery\MockInterface;
 use Tests\Models\Post;
 use Tests\Models\User;
 
 use function Pest\Livewire\livewire;
 
+function assertCommentKey($component, string $class, int|string $id): void
+{
+    $html = $component->html();
+
+    $literal = 'wire:key="' . $class . ':' . $id . '"';
+    $snapshot = trim(json_encode("$class:$id"), '"');
+
+    expect(str_contains($html, $literal) || str_contains($html, $snapshot))->toBeTrue();
+}
+
 test('CommentList calls getComments when not paginating', function () {
-    /** @var Post|Mockery\MockInterface $post */
+    /** @var Post|MockInterface $post */
     $post = Mockery::mock(Post::class)->makePartial();
 
     $post->shouldReceive('getComments')
@@ -26,7 +36,7 @@ test('CommentList calls getComments when not paginating', function () {
 });
 
 test('CommentList calls getComments when paginating', function () {
-    /** @var Post|Mockery\MockInterface $post */
+    /** @var Post|MockInterface $post */
     $post = Mockery::mock(Post::class)->makePartial();
 
     $post->shouldReceive('getComments')
@@ -43,7 +53,7 @@ test('CommentList calls getComments when paginating', function () {
 });
 
 test('CommentList can render non-Comment renderable items', function () {
-    /** @var Post|Mockery\MockInterface $post */
+    /** @var Post|MockInterface $post */
     $post = Mockery::mock(Post::class)->makePartial();
 
     $items = collect([
@@ -78,12 +88,13 @@ test('CommentList renders duplicate-content comments without key collision', fun
         'body' => 'identical body',
     ]);
 
-    livewire(CommentList::class, [
+    $component = livewire(CommentList::class, [
         'record' => $realPost,
         'paginate' => false,
-    ])
-        ->assertSeeHtml('wire:key="' . CommentModel::class . ':' . $first->id . '"')
-        ->assertSeeHtml('wire:key="' . CommentModel::class . ':' . $second->id . '"');
+    ]);
+
+    assertCommentKey($component, CommentModel::class, $first->id);
+    assertCommentKey($component, CommentModel::class, $second->id);
 });
 
 test('CommentList keeps comment keys stable across edits', function () {
@@ -97,16 +108,21 @@ test('CommentList keeps comment keys stable across edits', function () {
         'body' => 'original body',
     ]);
 
-    $key = 'wire:key="' . CommentModel::class . ':' . $comment->id . '"';
-
-    $component = livewire(CommentList::class, [
+    $before = livewire(CommentList::class, [
         'record' => $realPost,
         'paginate' => false,
-    ])->assertSeeHtml($key);
+    ]);
+
+    assertCommentKey($before, CommentModel::class, $comment->id);
 
     $comment->update(['body' => 'edited body']);
 
-    $component->call('reloadComments')->assertSeeHtml($key);
+    $after = livewire(CommentList::class, [
+        'record' => $realPost,
+        'paginate' => false,
+    ]);
+
+    assertCommentKey($after, CommentModel::class, $comment->id);
 });
 
 test('CommentList can render both Comment and RenderableComment items', function () {
@@ -127,7 +143,7 @@ test('CommentList can render both Comment and RenderableComment items', function
 
     $items = collect([$comment, $renderable]);
 
-    /** @var Post|Mockery\MockInterface $post */
+    /** @var Post|MockInterface $post */
     $post = Mockery::mock(Post::class)->makePartial();
     $post->shouldReceive('getComments')
         ->once()
@@ -162,16 +178,17 @@ test('CommentList renders Comment and RenderableComment sharing an id without ke
     // RenderableComment deliberately reuses the Comment's primary key.
     $renderable = new RenderableComment(id: $comment->id, authorName: 'System', body: 'System message');
 
-    /** @var Post|Mockery\MockInterface $post */
+    /** @var Post|MockInterface $post */
     $post = Mockery::mock(Post::class)->makePartial();
     $post->shouldReceive('getComments')
         ->once()
         ->andReturn(collect([$comment, $renderable]));
 
-    livewire(CommentList::class, [
+    $component = livewire(CommentList::class, [
         'record' => $post,
         'paginate' => false,
-    ])
-        ->assertSeeHtml('wire:key="' . CommentModel::class . ':' . $comment->id . '"')
-        ->assertSeeHtml('wire:key="' . RenderableComment::class . ':' . $renderable->getId() . '"');
+    ]);
+
+    assertCommentKey($component, CommentModel::class, $comment->id);
+    assertCommentKey($component, RenderableComment::class, $renderable->getId());
 });

--- a/tests/Livewire/CommentListTest.php
+++ b/tests/Livewire/CommentListTest.php
@@ -82,8 +82,31 @@ test('CommentList renders duplicate-content comments without key collision', fun
         'record' => $realPost,
         'paginate' => false,
     ])
-        ->assertSeeHtml('wire:key="' . $first->id . '"')
-        ->assertSeeHtml('wire:key="' . $second->id . '"');
+        ->assertSeeHtml('wire:key="' . CommentModel::class . ':' . $first->id . '"')
+        ->assertSeeHtml('wire:key="' . CommentModel::class . ':' . $second->id . '"');
+});
+
+test('CommentList keeps comment keys stable across edits', function () {
+    /** @var User $user */
+    $user = User::factory()->create();
+    /** @var Post $realPost */
+    $realPost = Post::factory()->create();
+
+    /** @var CommentModel $comment */
+    $comment = CommentModel::factory()->author($user)->commentable($realPost)->create([
+        'body' => 'original body',
+    ]);
+
+    $key = 'wire:key="' . CommentModel::class . ':' . $comment->id . '"';
+
+    $component = livewire(CommentList::class, [
+        'record' => $realPost,
+        'paginate' => false,
+    ])->assertSeeHtml($key);
+
+    $comment->update(['body' => 'edited body']);
+
+    $component->call('reloadComments')->assertSeeHtml($key);
 });
 
 test('CommentList can render both Comment and RenderableComment items', function () {
@@ -120,4 +143,35 @@ test('CommentList can render both Comment and RenderableComment items', function
         // From RenderableComment
         ->assertSee('System')
         ->assertSee('System message');
+});
+
+test('CommentList renders Comment and RenderableComment sharing an id without key collision', function () {
+    /** @var User $user */
+    $user = User::factory()->create();
+    /** @var Post $realPost */
+    $realPost = Post::factory()->create();
+
+    /** @var CommentModel $comment */
+    $comment = CommentModel::factory()
+        ->author($user)
+        ->commentable($realPost)
+        ->create([
+            'body' => 'Real comment body',
+        ]);
+
+    // RenderableComment deliberately reuses the Comment's primary key.
+    $renderable = new RenderableComment(id: $comment->id, authorName: 'System', body: 'System message');
+
+    /** @var Post|Mockery\MockInterface $post */
+    $post = Mockery::mock(Post::class)->makePartial();
+    $post->shouldReceive('getComments')
+        ->once()
+        ->andReturn(collect([$comment, $renderable]));
+
+    livewire(CommentList::class, [
+        'record' => $post,
+        'paginate' => false,
+    ])
+        ->assertSeeHtml('wire:key="' . CommentModel::class . ':' . $comment->id . '"')
+        ->assertSeeHtml('wire:key="' . RenderableComment::class . ':' . $renderable->getId() . '"');
 });

--- a/tests/Livewire/CommentListTest.php
+++ b/tests/Livewire/CommentListTest.php
@@ -65,6 +65,27 @@ test('CommentList can render non-Comment renderable items', function () {
         ->assertSee('Automated message');
 });
 
+test('CommentList renders duplicate-content comments without key collision', function () {
+    /** @var User $user */
+    $user = User::factory()->create();
+    /** @var Post $realPost */
+    $realPost = Post::factory()->create();
+
+    $first = CommentModel::factory()->author($user)->commentable($realPost)->create([
+        'body' => 'identical body',
+    ]);
+    $second = CommentModel::factory()->author($user)->commentable($realPost)->create([
+        'body' => 'identical body',
+    ]);
+
+    livewire(CommentList::class, [
+        'record' => $realPost,
+        'paginate' => false,
+    ])
+        ->assertSeeHtml('wire:key="' . $first->id . '"')
+        ->assertSeeHtml('wire:key="' . $second->id . '"');
+});
+
 test('CommentList can render both Comment and RenderableComment items', function () {
     /** @var User $user */
     $user = User::factory()->create();


### PR DESCRIPTION
Fixes #72.

## Problem

`comment-list.blade.php` keyed each child `<livewire:dynamic-component>` by
`$comment->getContentHash()`. For a `Comment`, `getContentHash()` returns
`md5(body + reaction ids)`, which has two failure modes:

1. **Unstable** — the hash changes whenever a comment is edited or reacted to,
   so the keyed component effectively re-keys itself mid-lifecycle.
2. **Collision-prone** — two comments with identical content produce the same
   hash, so they share a `wire:key`.

Either case breaks Livewire's DOM reconciliation and surfaces as
`Snapshot missing on Livewire component` errors.

**Reproduce:** post two comments with identical bodies, or edit / react to an
existing comment in a list — the component throws "Snapshot missing".

## Fix

Key each component by `$comment::class . ':' . $comment->getId()`:

- **Stable** — neither the class nor the primary key changes when a comment is
  edited or reacted to.
- **Unique per row** — `getId()` returns the primary key.
- **Namespaced by type** — prefixing with the class prevents a `Comment` and a
  `RenderableComment` that happen to share a numeric id from colliding. This is
  a real scenario when `getComments()` is overridden to merge non-comment items
  into the list.

## Deprecation

`getContentHash()` is no longer used anywhere in the package. It is marked
`@deprecated` on the `Contracts\RenderableComment` interface and both
implementations (`Comment`, `RenderableComment`). It is **not removed** — it is
part of the public contract, so removal is deferred to a future major version.

## Tests

Three tests added to `tests/Livewire/CommentListTest.php`:

- `renders duplicate-content comments without key collision` — two comments with
  identical bodies render distinct keys.
- `keeps comment keys stable across edits` — a comment's key is unchanged after
  its body is edited.
- `renders Comment and RenderableComment sharing an id without key collision` —
  a `Comment` and a `RenderableComment` with the same id render distinct keys.

## Backwards compatibility

No breaking changes. The `wire:key` value format is internal to Livewire's
rendering and is not a public API. `getContentHash()` remains callable
(deprecated only).