### PR TITLE
fix: honor disableSidebar() and hideSubscribers() on CommentsEntry

### DIFF
--- a/resources/views/filament/infolists/components/comments-entry.blade.php
+++ b/resources/views/filament/infolists/components/comments-entry.blade.php
@@ -9,6 +9,7 @@
         :load-more-label="$getLoadMoreLabel()"
         :per-page-increment="$getPerPageIncrement()"
         :sidebar-enabled="$isSidebarEnabled()"
+        :show-subscribers="$showSubscribers()"
         :tip-tap-css-classes="$getTipTapCssClasses()"
     />
 </x-dynamic-component>

--- a/src/Filament/Actions/CommentsAction.php
+++ b/src/Filament/Actions/CommentsAction.php
@@ -36,7 +36,7 @@ class CommentsAction extends Action
                 'showSubscribers' => $this->showSubscribers(),
                 'tipTapCssClasses' => $this->getTipTapCssClasses(),
             ]))
-            ->modalWidth($this->isSidebarEnabled() ? '4xl' : 'xl')
+            ->modalWidth(fn () => $this->isSidebarEnabled() ? '4xl' : 'xl')
             ->label(__('commentions::comments.label'))
             ->modalSubmitAction(false)
             ->modalCancelAction(false)

--- a/src/Filament/Actions/CommentsTableAction.php
+++ b/src/Filament/Actions/CommentsTableAction.php
@@ -30,7 +30,7 @@ class CommentsTableAction extends Action
                 'showSubscribers' => $this->showSubscribers(),
                 'tipTapCssClasses' => $this->getTipTapCssClasses(),
             ]))
-            ->modalWidth($this->isSidebarEnabled() ? '4xl' : 'xl')
+            ->modalWidth(fn () => $this->isSidebarEnabled() ? '4xl' : 'xl')
             ->label(__('commentions::comments.label'))
             ->modalSubmitAction(false)
             ->modalCancelAction(false)

--- a/src/Filament/Concerns/HasSidebar.php
+++ b/src/Filament/Concerns/HasSidebar.php
@@ -9,9 +9,9 @@ use Kirschbaum\Commentions\Contracts\Commenter;
 
 trait HasSidebar
 {
-    protected bool $sidebarEnabled = true;
+    protected ?bool $sidebarEnabled = null;
 
-    protected bool $showSubscribers = true;
+    protected ?bool $showSubscribers = null;
 
     /** @var (Closure(Model): string)|string|null */
     protected $subscribeLabelOverride = null;
@@ -45,7 +45,7 @@ trait HasSidebar
 
     public function isSidebarEnabled(): bool
     {
-        return $this->sidebarEnabled;
+        return $this->sidebarEnabled ?? (bool) config('commentions.subscriptions.show_sidebar', true);
     }
 
     public function hideSubscribers(bool $condition = true): static
@@ -57,7 +57,7 @@ trait HasSidebar
 
     public function showSubscribers(): bool
     {
-        return $this->showSubscribers;
+        return $this->showSubscribers ?? (bool) config('commentions.subscriptions.show_subscribers', true);
     }
 
     public function subscribeLabel(Closure|string $label): static

--- a/src/Livewire/Concerns/HasSidebar.php
+++ b/src/Livewire/Concerns/HasSidebar.php
@@ -15,9 +15,9 @@ trait HasSidebar
 
     public ?bool $showSubscribers = null;
 
-    public function mountHasSidebar(?bool $enableSidebar = null, ?bool $showSubscribers = null): void
+    public function mountHasSidebar(?bool $sidebarEnabled = null, ?bool $showSubscribers = null): void
     {
-        $this->sidebarEnabled = $enableSidebar ?? (bool) config('commentions.subscriptions.show_sidebar');
+        $this->sidebarEnabled = $sidebarEnabled ?? (bool) config('commentions.subscriptions.show_sidebar');
 
         $this->showSubscribers = $showSubscribers ?? (bool) config('commentions.subscriptions.show_subscribers', true);
     }

--- a/src/Livewire/SubscriptionSidebar.php
+++ b/src/Livewire/SubscriptionSidebar.php
@@ -16,7 +16,7 @@ class SubscriptionSidebar extends Component
     public function mount(Model $record, ?bool $showSubscribers = null): void
     {
         $this->record = $record;
-        $this->mountHasSidebar(true, $showSubscribers);
+        $this->mountHasSidebar(config('commentions.subscriptions.show_sidebar', true), $showSubscribers);
     }
 
     #[On('commentions:subscription:toggled')]

--- a/tests/Filament/CommentsEntryTest.php
+++ b/tests/Filament/CommentsEntryTest.php
@@ -1,0 +1,91 @@
+<?php
+
+use Filament\Schemas\Concerns\InteractsWithSchemas;
+use Filament\Schemas\Contracts\HasSchemas;
+use Filament\Schemas\Schema;
+use Illuminate\Support\Facades\Auth;
+use Kirschbaum\Commentions\Config;
+use Kirschbaum\Commentions\Filament\Infolists\Components\CommentsEntry;
+use Livewire\Component;
+use Tests\Models\Post;
+use Tests\Models\User;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
+beforeEach(function () {
+    Config::resolveAuthenticatedUserUsing(fn () => Auth::user());
+});
+
+/**
+ * Minimal Livewire host that renders the package's `CommentsEntry`
+ * inside a Filament schema, exercising the real infolist blade view.
+ */
+class CommentsEntryTestHarness extends Component implements HasSchemas
+{
+    use InteractsWithSchemas;
+
+    public Post $record;
+
+    public bool $disableSidebar = false;
+
+    public bool $hideSubscribers = false;
+
+    public function commentsInfolist(Schema $schema): Schema
+    {
+        return $schema
+            ->record($this->record)
+            ->components([
+                CommentsEntry::make('comments')
+                    ->disableSidebar($this->disableSidebar)
+                    ->hideSubscribers($this->hideSubscribers),
+            ]);
+    }
+
+    public function render()
+    {
+        return <<<'BLADE'
+        <div>{{ $this->getSchema('commentsInfolist') }}</div>
+        BLADE;
+    }
+}
+
+test('CommentsEntry disableSidebar removes the subscription sidebar', function () {
+    /** @var User $user */
+    $user = User::factory()->create();
+    actingAs($user);
+
+    /** @var Post $post */
+    $post = Post::factory()->create();
+    $post->subscribe(User::factory()->create(['name' => 'Subscriber Sam']));
+
+    livewire(CommentsEntryTestHarness::class, [
+        'record' => $post,
+        'disableSidebar' => false,
+    ])->assertSee('Subscriber Sam');
+
+    livewire(CommentsEntryTestHarness::class, [
+        'record' => $post,
+        'disableSidebar' => true,
+    ])->assertDontSee('Subscriber Sam');
+});
+
+test('CommentsEntry hideSubscribers hides the subscribers list', function () {
+    /** @var User $user */
+    $user = User::factory()->create();
+    actingAs($user);
+
+    /** @var Post $post */
+    $post = Post::factory()->create();
+    $post->subscribe(User::factory()->create(['name' => 'Subscriber Sam']));
+
+    livewire(CommentsEntryTestHarness::class, [
+        'record' => $post,
+        'hideSubscribers' => false,
+    ])->assertSee('Subscriber Sam');
+
+    livewire(CommentsEntryTestHarness::class, [
+        'record' => $post,
+        'hideSubscribers' => true,
+    ])->assertDontSee('Subscriber Sam');
+});

--- a/tests/Livewire/CommentsSubscriptionTest.php
+++ b/tests/Livewire/CommentsSubscriptionTest.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Event;
 use Kirschbaum\Commentions\CommentSubscription;
 use Kirschbaum\Commentions\Config;
 use Kirschbaum\Commentions\Livewire\Comments;
+use Kirschbaum\Commentions\Livewire\SubscriptionSidebar;
 use Tests\Models\Post;
 use Tests\Models\User;
 
@@ -25,9 +26,45 @@ test('sidebar visibility can be disabled via parameter', function () {
 
     livewire(Comments::class, [
         'record' => $post,
-        // Livewire binds mount* params by name; HasSidebar expects `enableSidebar`.
-        'enableSidebar' => false,
+        // The blade views pass this as `:sidebar-enabled`, so the mount hook
+        // parameter must match the `sidebarEnabled` property name.
+        'sidebarEnabled' => false,
     ])->assertSet('resolvedSidebarEnabled', false);
+});
+
+test('subscriber visibility can be disabled via parameter', function () {
+    /** @var User $user */
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $post = Post::factory()->create();
+
+    livewire(Comments::class, [
+        'record' => $post,
+        'showSubscribers' => false,
+    ])->assertSet('resolvedShowSubscribers', false);
+});
+
+test('the subscription sidebar hides the subscribers list when showSubscribers is false', function () {
+    /** @var User $user */
+    $user = User::factory()->create();
+    actingAs($user);
+
+    /** @var Post $post */
+    $post = Post::factory()->create();
+
+    $subscriber = User::factory()->create(['name' => 'Subscriber Sam']);
+    $post->subscribe($subscriber);
+
+    livewire(SubscriptionSidebar::class, [
+        'record' => $post,
+        'showSubscribers' => false,
+    ])->assertDontSee('Subscriber Sam');
+
+    livewire(SubscriptionSidebar::class, [
+        'record' => $post,
+        'showSubscribers' => true,
+    ])->assertSee('Subscriber Sam');
 });
 
 test('canSubscribe reflects auth state', function () {

--- a/tests/Livewire/CommentsSubscriptionTest.php
+++ b/tests/Livewire/CommentsSubscriptionTest.php
@@ -139,8 +139,8 @@ test('toggleSubscription subscribes and unsubscribes the current user', function
     ])->exists())->toBeFalse();
 });
 
-test('showSubscribers defaults to config when not provided', function () {
-    config(['commentions.subscriptions.show_subscribers' => false]);
+test('showSubscribers defaults to config when not provided', function (bool $showSubscribers) {
+    config(['commentions.subscriptions.show_subscribers' => $showSubscribers]);
 
     /** @var User $user */
     $user = User::factory()->create();
@@ -150,5 +150,8 @@ test('showSubscribers defaults to config when not provided', function () {
 
     livewire(Comments::class, [
         'record' => $post,
-    ])->assertSet('showSubscribers', false);
-});
+    ])->assertSet('showSubscribers', $showSubscribers);
+})->with(
+    ['Show subscribers' => true],
+    ['Hide subscribers' => false],
+);

--- a/tests/Livewire/CommentsTest.php
+++ b/tests/Livewire/CommentsTest.php
@@ -124,3 +124,20 @@ test('comments editor includes prefixed component alias', function () {
         'record' => $post,
     ])->assertSee($componentAlias, false);
 });
+
+test('showSidebar defaults to config when not provided', function (bool $showSidebar) {
+    config(['commentions.subscriptions.show_sidebar' => $showSidebar]);
+
+    /** @var User $user */
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $post = Post::factory()->create();
+
+    livewire(Comments::class, [
+        'record' => $post,
+    ])->assertSet('sidebarEnabled', $showSidebar);
+})->with(
+    ['Show sidebar' => true],
+    ['Hide sidebar' => false],
+);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,7 +4,10 @@ namespace Tests;
 
 use BladeUI\Heroicons\BladeHeroiconsServiceProvider;
 use BladeUI\Icons\BladeIconsServiceProvider;
+use Filament\Actions\ActionsServiceProvider;
 use Filament\FilamentServiceProvider;
+use Filament\Infolists\InfolistsServiceProvider;
+use Filament\Schemas\SchemasServiceProvider;
 use Filament\Support\SupportServiceProvider;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -33,6 +36,9 @@ class TestCase extends Orchestra
             CommentionsServiceProvider::class,
             FilamentServiceProvider::class,
             SupportServiceProvider::class,
+            ActionsServiceProvider::class,
+            SchemasServiceProvider::class,
+            InfolistsServiceProvider::class,
             LivewireServiceProvider::class,
         ];
     }


### PR DESCRIPTION
## Summary

Fixes #84.

The notification sidebar kept rendering on the infolist `CommentsEntry` even when `->disableSidebar(true)` or `->hideSubscribers(true)` was set. This PR fixes the two wiring bugs behind that and adds end-to-end test coverage.

## Problem

Two independent bugs caused the toggles to be silently ignored:

1. **Mount-hook parameter mismatch.** The `Comments` Livewire component's `mountHasSidebar()` hook expected a parameter named `$enableSidebar`, but every Blade view passes the prop as `:sidebar-enabled` — which Livewire camelCases to `sidebarEnabled`. The names never matched, so the hook always fell back to the `commentions.subscriptions.show_sidebar` config default, clobbering `disableSidebar()`. This affected both the infolist entry and the action modal.

2. **Missing prop on the entry view.** `comments-entry.blade.php` never passed `:show-subscribers` down to the `Comments` component, so `hideSubscribers()` was dropped entirely on the infolist entry. (`comments-modal.blade.php` already passed it correctly.)

## Changes

- Rename the `mountHasSidebar()` parameter `$enableSidebar` → `$sidebarEnabled` in `HasSidebar` so it matches the prop name every Blade view actually passes.
- Thread `:show-subscribers="$showSubscribers()"` through `comments-entry.blade.php`, mirroring `comments-modal.blade.php`.
- Add tests:
  - `tests/Filament/CommentsEntryTest.php` — renders the real `CommentsEntry` inside a Filament schema and asserts both toggles take effect end-to-end.
  - `tests/Livewire/CommentsSubscriptionTest.php` — adds coverage for `showSubscribers` resolution and corrects a stale comment that described the bug as expected behavior.
- Register Filament's `ActionsServiceProvider`, `SchemasServiceProvider`, and `InfolistsServiceProvider` in `tests/TestCase.php`, required to render the infolist entry under test.