### PR TITLE
Update phpstan.neon

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -47,7 +47,7 @@ parameters:
             path: src/RenderableComment.php
 
         -
-            message: '#^Call to an undefined method PHPUnit\\Framework\\TestCase::[a-zA-Z0-9_]+\(\)\.$#'
+            message: '#^Call to an undefined method Pest\\PendingCalls\\TestCall::[a-zA-Z0-9_]+\(\)\.$#'
             identifier: method.notFound
             count: 3
             path: tests/**/*.php
@@ -58,13 +58,13 @@ parameters:
             path: tests/Pest.php
 
         -
-            message: '#^Call to an undefined method PHPUnit\\Framework\\TestCase\:\:assertDatabaseHas\(\)\.$#'
+            message: '#^Call to an undefined method Pest\\PendingCalls\\TestCall\:\:assertDatabaseHas\(\)\.$#'
             identifier: method.notFound
             count: 2
             path: tests/Livewire/CommentReactionTest.php
 
         -
-            message: '#^Call to an undefined method PHPUnit\\Framework\\TestCase\:\:assertDatabaseMissing\(\)\.$#'
+            message: '#^Call to an undefined method Pest\\PendingCalls\\TestCall\:\:assertDatabaseMissing\(\)\.$#'
             identifier: method.notFound
             count: 3
             path: tests/Livewire/CommentReactionTest.php


### PR DESCRIPTION
This pull request updates the static analysis configuration to reflect the use of Pest's testing framework instead of PHPUnit in the test suite. The changes ensure that method-not-found error patterns in `phpstan.neon` now correctly reference Pest's classes.

Test framework configuration updates:

* Updated error message patterns in `phpstan.neon` to match undefined method calls on `Pest\PendingCalls\TestCall` instead of `PHPUnit\Framework\TestCase`. This affects checks for general undefined methods, as well as `assertDatabaseHas` and `assertDatabaseMissing` in test files. [[1]](diffhunk://#diff-0361f0c81f363476ddc6f44ab36fcbe66ee685d5f4c2a46b054924591544b766L50-R50) [[2]](diffhunk://#diff-0361f0c81f363476ddc6f44ab36fcbe66ee685d5f4c2a46b054924591544b766L61-R67)