### PR TITLE
Support a configurable display timezone for comment timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ use Kirschbaum\Commentions\Config;
 Config::resolveTimezoneUsing(fn () => auth()->user()?->timezone);
 ```
 
-The closure takes precedence over the config value. When both are `null`, dates render in the storage timezone.
+The closure result takes precedence; when it returns `null`, the `timezone` config value is used as a fallback. When neither yields a value, dates render in the storage timezone.
 
 ### Customizing TipTap Editor Styles
 

--- a/README.md
+++ b/README.md
@@ -396,6 +396,26 @@ class User extends Authenticatable implements Commenter, HasName, HasAvatar
 }
 ```
 
+### Adjusting the display timezone
+
+Comment timestamps are stored in the app default timezone, but can be displayed in a different one. Set the `timezone` config key for a fixed override, or wire a closure for per-request resolution (e.g. the authenticated user's timezone):
+
+```php
+// config/commentions.php
+return [
+    // ...
+    'timezone' => 'America/Chicago',
+];
+```
+
+```php
+use Kirschbaum\Commentions\Config;
+
+Config::resolveTimezoneUsing(fn () => auth()->user()?->timezone);
+```
+
+The closure takes precedence over the config value. When both are `null`, dates render in the storage timezone.
+
 ### Customizing TipTap Editor Styles
 
 You can customize the TipTap editor CSS classes used using the `Config` class.

--- a/config/commentions.php
+++ b/config/commentions.php
@@ -48,6 +48,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Display timezone
+    |--------------------------------------------------------------------------
+    |
+    | Timezone applied when rendering comment created/updated timestamps.
+    | When null, dates are rendered in the storage timezone (typically the
+    | app default). Set to an IANA name like "America/Chicago", or wire a
+    | per-user value via Config::resolveTimezoneUsing(fn () => auth()->user()?->timezone).
+    |
+    */
+    'timezone' => null,
+
+    /*
+    |--------------------------------------------------------------------------
     | Subscriptions
     |--------------------------------------------------------------------------
     */

--- a/src/Comment.php
+++ b/src/Comment.php
@@ -152,12 +152,12 @@ class Comment extends Model implements RenderableComment
 
     public function getCreatedAt(): DateTime|CarbonInterface
     {
-        return $this->created_at;
+        return Config::applyTimezone($this->created_at);
     }
 
     public function getUpdatedAt(): DateTime|CarbonInterface
     {
-        return $this->updated_at;
+        return Config::applyTimezone($this->updated_at);
     }
 
     public function reactions(): HasMany

--- a/src/Config.php
+++ b/src/Config.php
@@ -17,6 +17,8 @@ class Config
 
     protected static ?Closure $resolveTipTapCssClasses = null;
 
+    protected static ?Closure $resolveTimezone = null;
+
     public static function resolveAuthenticatedUserUsing(Closure $callback): void
     {
         static::$resolveAuthenticatedUser = $callback;
@@ -99,6 +101,38 @@ class Config
     public static function getComponentPrefix(): string
     {
         return static::isLivewireV4() ? 'commentions.' : 'commentions::';
+    }
+
+    public static function resolveTimezoneUsing(Closure $callback): void
+    {
+        static::$resolveTimezone = $callback;
+    }
+
+    public static function getTimezone(): ?string
+    {
+        if (static::$resolveTimezone instanceof Closure) {
+            return call_user_func(static::$resolveTimezone);
+        }
+
+        return config('commentions.timezone');
+    }
+
+    public static function applyTimezone(\DateTime|\Carbon\CarbonInterface $dt): \DateTime|\Carbon\CarbonInterface
+    {
+        $tz = static::getTimezone();
+
+        if ($tz === null) {
+            return $dt;
+        }
+
+        if ($dt instanceof \Carbon\CarbonInterface) {
+            return $dt->copy()->setTimezone($tz);
+        }
+
+        $cloned = clone $dt;
+        $cloned->setTimezone(new \DateTimeZone($tz));
+
+        return $cloned;
     }
 
     public static function isLivewireV4(): bool

--- a/src/Config.php
+++ b/src/Config.php
@@ -2,8 +2,11 @@
 
 namespace Kirschbaum\Commentions;
 
+use Carbon\CarbonInterface;
 use Closure;
 use Composer\InstalledVersions;
+use DateTime;
+use DateTimeZone;
 use InvalidArgumentException;
 use Kirschbaum\Commentions\Contracts\Commenter;
 
@@ -103,7 +106,7 @@ class Config
         return static::isLivewireV4() ? 'commentions.' : 'commentions::';
     }
 
-    public static function resolveTimezoneUsing(Closure $callback): void
+    public static function resolveTimezoneUsing(?Closure $callback = null): void
     {
         static::$resolveTimezone = $callback;
     }
@@ -111,26 +114,26 @@ class Config
     public static function getTimezone(): ?string
     {
         if (static::$resolveTimezone instanceof Closure) {
-            return call_user_func(static::$resolveTimezone);
+            return call_user_func(static::$resolveTimezone) ?? config('commentions.timezone');
         }
 
         return config('commentions.timezone');
     }
 
-    public static function applyTimezone(\DateTime|\Carbon\CarbonInterface $dt): \DateTime|\Carbon\CarbonInterface
+    public static function applyTimezone(DateTime|CarbonInterface $dt): DateTime|CarbonInterface
     {
         $tz = static::getTimezone();
 
-        if ($tz === null) {
+        if (blank($tz)) {
             return $dt;
         }
 
-        if ($dt instanceof \Carbon\CarbonInterface) {
+        if ($dt instanceof CarbonInterface) {
             return $dt->copy()->setTimezone($tz);
         }
 
         $cloned = clone $dt;
-        $cloned->setTimezone(new \DateTimeZone($tz));
+        $cloned->setTimezone(new DateTimeZone($tz));
 
         return $cloned;
     }

--- a/src/RenderableComment.php
+++ b/src/RenderableComment.php
@@ -82,12 +82,12 @@ class RenderableComment implements RenderableCommentContract, Wireable
 
     public function getCreatedAt(): DateTime|CarbonInterface
     {
-        return $this->createdAt;
+        return Config::applyTimezone($this->createdAt);
     }
 
     public function getUpdatedAt(): DateTime|CarbonInterface
     {
-        return $this->updatedAt;
+        return Config::applyTimezone($this->updatedAt);
     }
 
     public function getLabel(): ?string

--- a/tests/TimezoneTest.php
+++ b/tests/TimezoneTest.php
@@ -9,7 +9,7 @@ use Tests\Models\User;
 
 afterEach(function () {
     config()->set('commentions.timezone', null);
-    Config::resolveTimezoneUsing(fn () => config('commentions.timezone'));
+    Config::resolveTimezoneUsing(null);
 });
 
 test('comment dates are returned unmodified when no timezone is configured', function () {
@@ -79,4 +79,28 @@ test('applyTimezone does not mutate the source instance', function () {
 
     expect($source->format('Y-m-d H:i'))->toBe('2026-01-15 12:00')
         ->and($converted->format('Y-m-d H:i'))->toBe('2026-01-15 07:00');
+});
+
+test('an empty-string timezone is treated as no timezone', function () {
+    Config::resolveTimezoneUsing(fn () => '');
+
+    $source = Carbon::parse('2026-01-15 12:00:00', 'UTC');
+
+    expect(Config::applyTimezone($source)->format('Y-m-d H:i'))
+        ->toBe('2026-01-15 12:00');
+});
+
+test('resolveTimezoneUsing falls back to the config value when the closure returns null', function () {
+    config()->set('commentions.timezone', 'America/Chicago');
+    Config::resolveTimezoneUsing(fn () => null);
+
+    $user = User::factory()->create();
+    $post = Post::factory()->create();
+    $comment = CommentModel::factory()->author($user)->commentable($post)->create([
+        'created_at' => Carbon::parse('2026-01-15 12:00:00', 'UTC'),
+        'updated_at' => Carbon::parse('2026-01-15 12:00:00', 'UTC'),
+    ]);
+
+    expect($comment->getCreatedAt()->format('Y-m-d H:i'))
+        ->toBe('2026-01-15 06:00');
 });

--- a/tests/TimezoneTest.php
+++ b/tests/TimezoneTest.php
@@ -1,0 +1,82 @@
+<?php
+
+use Carbon\Carbon;
+use Kirschbaum\Commentions\Comment as CommentModel;
+use Kirschbaum\Commentions\Config;
+use Kirschbaum\Commentions\RenderableComment;
+use Tests\Models\Post;
+use Tests\Models\User;
+
+afterEach(function () {
+    config()->set('commentions.timezone', null);
+    Config::resolveTimezoneUsing(fn () => config('commentions.timezone'));
+});
+
+test('comment dates are returned unmodified when no timezone is configured', function () {
+    config()->set('commentions.timezone', null);
+
+    $user = User::factory()->create();
+    $post = Post::factory()->create();
+    $comment = CommentModel::factory()->author($user)->commentable($post)->create([
+        'created_at' => Carbon::parse('2026-01-15 12:00:00', 'UTC'),
+        'updated_at' => Carbon::parse('2026-01-15 12:00:00', 'UTC'),
+    ]);
+
+    expect($comment->getCreatedAt()->format('Y-m-d H:i:s'))
+        ->toBe('2026-01-15 12:00:00');
+});
+
+test('comment dates are converted when a timezone is configured', function () {
+    config()->set('commentions.timezone', 'America/Chicago');
+
+    $user = User::factory()->create();
+    $post = Post::factory()->create();
+    $comment = CommentModel::factory()->author($user)->commentable($post)->create([
+        'created_at' => Carbon::parse('2026-01-15 12:00:00', 'UTC'),
+        'updated_at' => Carbon::parse('2026-01-15 12:00:00', 'UTC'),
+    ]);
+
+    expect($comment->getCreatedAt()->format('Y-m-d H:i'))
+        ->toBe('2026-01-15 06:00');
+});
+
+test('RenderableComment dates respect the timezone config', function () {
+    config()->set('commentions.timezone', 'Asia/Tokyo');
+
+    $renderable = new RenderableComment(
+        id: 1,
+        authorName: 'System',
+        body: 'Test',
+        createdAt: Carbon::parse('2026-01-15 12:00:00', 'UTC'),
+        updatedAt: Carbon::parse('2026-01-15 12:00:00', 'UTC'),
+    );
+
+    expect($renderable->getCreatedAt()->format('Y-m-d H:i'))
+        ->toBe('2026-01-15 21:00');
+});
+
+test('resolveTimezoneUsing closure takes precedence over config', function () {
+    config()->set('commentions.timezone', 'UTC');
+    Config::resolveTimezoneUsing(fn () => 'Europe/London');
+
+    $user = User::factory()->create();
+    $post = Post::factory()->create();
+    $comment = CommentModel::factory()->author($user)->commentable($post)->create([
+        'created_at' => Carbon::parse('2026-06-15 12:00:00', 'UTC'),
+        'updated_at' => Carbon::parse('2026-06-15 12:00:00', 'UTC'),
+    ]);
+
+    // London is BST (UTC+1) in June
+    expect($comment->getCreatedAt()->format('Y-m-d H:i'))
+        ->toBe('2026-06-15 13:00');
+});
+
+test('applyTimezone does not mutate the source instance', function () {
+    config()->set('commentions.timezone', 'America/New_York');
+
+    $source = Carbon::parse('2026-01-15 12:00:00', 'UTC');
+    $converted = Config::applyTimezone($source);
+
+    expect($source->format('Y-m-d H:i'))->toBe('2026-01-15 12:00')
+        ->and($converted->format('Y-m-d H:i'))->toBe('2026-01-15 07:00');
+});


### PR DESCRIPTION
Closes #17.

### Summary

Comment timestamps are stored in the app's default timezone and, until now, were
always *rendered* in that same timezone. This PR adds an opt-in way to render them
in a different timezone — either a fixed app-wide value or a per-request value such
as the authenticated user's timezone.

### What changed

- **New config key** `commentions.timezone` (defaults to `null`).
- **New `Config` API:**
  - `Config::resolveTimezoneUsing(?Closure $callback = null)` — register a closure
    for per-request resolution; passing `null` clears it.
  - `Config::getTimezone(): ?string` — resolves the effective timezone.
  - `Config::applyTimezone(DateTime|CarbonInterface $dt)` — returns a timezone-adjusted
    copy of a date.
- `Comment::getCreatedAt()` / `getUpdatedAt()` and the matching `RenderableComment`
  getters now pass their value through `Config::applyTimezone()`.
- Documentation added to `README.md` and `config/commentions.php`.

### Behaviour details

- **Resolution order:** the closure result takes precedence; when it returns `null`
  it falls back to the `commentions.timezone` config value; when neither yields a
  value, dates render in the storage timezone (unchanged behaviour).
- **Non-mutating:** `applyTimezone()` returns a copy (`->copy()` for Carbon,
  `clone` for `DateTime`) and never mutates the source instance.
- **Blank-safe:** an empty-string result (e.g. an unset `users.timezone` column) is
  treated the same as `null`, so it can't throw an `InvalidTimeZoneException` at
  render time.

### Usage

```php
// config/commentions.php — fixed, app-wide
'timezone' => 'America/Chicago',
```

```php
// per-user resolution
use Kirschbaum\Commentions\Config;

Config::resolveTimezoneUsing(fn () => auth()->user()?->timezone);
```

### Testing

Added `tests/TimezoneTest.php` (7 tests) covering: no-timezone passthrough, fixed
config conversion, the `RenderableComment` path, closure-over-config precedence,
config fallback when the closure returns `null`, empty-string handling, and
source-instance non-mutation.