### PR TITLE
Render comment edit/delete as Filament actions & allow custom actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,21 @@ class User extends Authenticatable implements Commenter, HasName, HasAvatar
 }
 ```
 
+### Configuring custom actions
+
+Add additional actions next to edit/delete:
+
+```bash
+use Kirschbaum\Commentions\Config;
+use Filament\Actions\Action;
+
+Config::registerCommentActions(fn ($comment) => Action::make('activityLogs')
+    ->icon('heroicon-s-clock')
+    ->iconButton()
+    ->modalContent(/* ... */)
+);
+```
+
 ### Customizing TipTap Editor Styles
 
 You can customize the TipTap editor CSS classes used using the `Config` class.

--- a/resources/lang/ar/comments.php
+++ b/resources/lang/ar/comments.php
@@ -17,6 +17,7 @@ return [
 
     'cancel' => 'إلغاء',
     'delete' => 'حذف',
+    'edit' => 'تعديل',
     'save' => 'حفظ',
     'comment' => 'تعليق',
     'add_reaction' => 'إضافة رد فعل',

--- a/resources/lang/en/comments.php
+++ b/resources/lang/en/comments.php
@@ -17,6 +17,7 @@ return [
 
     'cancel' => 'Cancel',
     'delete' => 'Delete',
+    'edit' => 'Edit',
     'save' => 'Save',
     'comment' => 'Comment',
     'add_reaction' => 'Add Reaction',

--- a/resources/lang/es/comments.php
+++ b/resources/lang/es/comments.php
@@ -17,6 +17,7 @@ return [
 
     'cancel' => 'Cancelar',
     'delete' => 'Eliminar',
+    'edit' => 'Editar',
     'save' => 'Guardar',
     'comment' => 'Comentar',
     'add_reaction' => 'Agregar reacción',

--- a/resources/lang/fr/comments.php
+++ b/resources/lang/fr/comments.php
@@ -17,6 +17,7 @@ return [
 
     'cancel' => 'Annuler',
     'delete' => 'Supprimer',
+    'edit' => 'Modifier',
     'save' => 'Enregistrer',
     'comment' => 'Commenter',
     'add_reaction' => 'Ajouter une réaction',

--- a/resources/lang/nl/comments.php
+++ b/resources/lang/nl/comments.php
@@ -16,6 +16,7 @@ return [
 
     'cancel' => 'Annuleren',
     'delete' => 'Verwijderen',
+    'edit' => 'Bewerken',
     'save' => 'Opslaan',
     'comment' => 'Opmerking',
     'add_reaction' => 'Reactie toevoegen',

--- a/resources/lang/ro/comments.php
+++ b/resources/lang/ro/comments.php
@@ -17,6 +17,7 @@ return [
 
     'cancel' => 'Anulare',
     'delete' => 'Șterge',
+    'edit' => 'Editează',
     'save' => 'Salvare',
     'comment' => 'Comentariu',
     'add_reaction' => 'Adaugă reacție',

--- a/resources/views/comment.blade.php
+++ b/resources/views/comment.blade.php
@@ -1,5 +1,3 @@
-@use('\Kirschbaum\Commentions\Config')
-
 <div class="comm:flex comm:items-start comm:gap-x-4 comm:border comm:border-gray-300 comm:dark:border-gray-700 comm:p-4 comm:rounded-lg comm:shadow-sm comm:mb-2" id="filament-comment-{{ $comment->getId() }}">
     @if ($avatar = $comment->getAuthorAvatar())
         <img
@@ -34,57 +32,14 @@
                 @endif
             </div>
 
-            @if ($comment->isComment() && Config::resolveAuthenticatedUser()?->canAny(['update', 'delete'], $comment))
+            @if ($comment->isComment())
                 <div class="comm:flex comm:gap-x-1">
-                    @if (Config::resolveAuthenticatedUser()?->can('update', $comment))
-                        <x-filament::icon-button
-                            icon="heroicon-s-pencil-square"
-                            wire:click="edit"
-                            size="xs"
-                            color="gray"
-                        />
-                    @endif
+                    {{ $this->editAction }}
+                    {{ $this->deleteAction }}
 
-                    @if (Config::resolveAuthenticatedUser()?->can('delete', $comment))
-                        <x-filament::modal
-                            id="delete-comment-modal-{{ $comment->getId() }}"
-                            width="sm"
-                        >
-                            <x-slot name="trigger">
-                                <x-filament::icon-button
-                                    icon="heroicon-s-trash"
-                                    size="xs"
-                                    color="gray"
-                                />
-                            </x-slot>
-
-                            <x-slot name="heading">
-                                {{ __('commentions::comments.delete_comment_heading') }}
-                            </x-slot>
-
-                            <div class="comm:py-4">
-                                {{ __('commentions::comments.delete_comment_body') }}
-                            </div>
-
-                            <x-slot name="footer">
-                                <div class="comm:flex comm:justify-end comm:gap-x-4">
-                                    <x-filament::button
-                                        wire:click="$dispatch('close-modal', { id: 'delete-comment-modal-{{ $comment->getId() }}' })"
-                                        color="gray"
-                                    >
-                                        {{ __('commentions::comments.cancel') }}
-                                    </x-filament::button>
-
-                                    <x-filament::button
-                                        wire:click="delete"
-                                        color="danger"
-                                    >
-                                        {{ __('commentions::comments.delete') }}
-                                    </x-filament::button>
-                                </div>
-                            </x-slot>
-                        </x-filament::modal>
-                    @endif
+                    @foreach ($this->getCustomActions() as $commentAction)
+                        {{ $commentAction }}
+                    @endforeach
                 </div>
             @endif
         </div>
@@ -134,4 +89,6 @@
             @endif
         @endif
     </div>
+
+    <x-filament-actions::modals />
 </div>

--- a/src/Config.php
+++ b/src/Config.php
@@ -4,6 +4,8 @@ namespace Kirschbaum\Commentions;
 
 use Closure;
 use Composer\InstalledVersions;
+use Filament\Actions\Action;
+use Illuminate\Support\Arr;
 use InvalidArgumentException;
 use Kirschbaum\Commentions\Contracts\Commenter;
 
@@ -16,6 +18,9 @@ class Config
     protected static ?Closure $resolveCommentUrl = null;
 
     protected static ?Closure $resolveTipTapCssClasses = null;
+
+    /** @var array<Closure> */
+    protected static array $commentActions = [];
 
     public static function resolveAuthenticatedUserUsing(Closure $callback): void
     {
@@ -94,6 +99,36 @@ class Config
         }
 
         return 'comm:prose comm:dark:prose-invert comm:prose-sm comm:sm:prose-base comm:lg:prose-lg comm:xl:prose-2xl comm:focus:outline-none comm:p-4 comm:min-w-full comm:w-full comm:rounded-lg comm:border comm:border-gray-300 comm:dark:border-gray-700';
+    }
+
+    /**
+     * Register a callback that returns one or more Filament actions to render
+     * alongside each comment's built-in edit/delete actions. The callback
+     * receives the Comment the actions are being rendered for.
+     *
+     * @param  Closure(Comment): (Action|array<Action>)  $callback
+     */
+    public static function registerCommentActions(Closure $callback): void
+    {
+        static::$commentActions[] = $callback;
+    }
+
+    /**
+     * Resolve the custom actions registered for a given comment.
+     *
+     * @return array<Action>
+     */
+    public static function getCommentActions(Comment $comment): array
+    {
+        return collect(static::$commentActions)
+            ->flatMap(fn (Closure $callback): array => Arr::wrap($callback($comment)))
+            ->values()
+            ->all();
+    }
+
+    public static function flushCommentActions(): void
+    {
+        static::$commentActions = [];
     }
 
     public static function getComponentPrefix(): string

--- a/src/Livewire/Comment.php
+++ b/src/Livewire/Comment.php
@@ -2,19 +2,29 @@
 
 namespace Kirschbaum\Commentions\Livewire;
 
+use Filament\Actions\Concerns\InteractsWithActions;
+use Filament\Actions\Contracts\HasActions;
 use Filament\Notifications\Notification;
+use Filament\Schemas\Concerns\InteractsWithSchemas;
+use Filament\Schemas\Concerns\ResolvesDynamicLivewireProperties;
+use Filament\Schemas\Contracts\HasSchemas;
 use Illuminate\Contracts\View\View;
 use Kirschbaum\Commentions\Comment as CommentModel;
 use Kirschbaum\Commentions\Config;
 use Kirschbaum\Commentions\Contracts\RenderableComment;
+use Kirschbaum\Commentions\Livewire\Concerns\HasCommentActions;
 use Kirschbaum\Commentions\Livewire\Concerns\HasMentions;
 use Livewire\Attributes\On;
 use Livewire\Attributes\Renderless;
 use Livewire\Component;
 
-class Comment extends Component
+class Comment extends Component implements HasActions, HasSchemas
 {
+    use HasCommentActions;
     use HasMentions;
+    use InteractsWithActions;
+    use InteractsWithSchemas;
+    use ResolvesDynamicLivewireProperties;
 
     public CommentModel|RenderableComment $comment;
 

--- a/src/Livewire/Concerns/HasCommentActions.php
+++ b/src/Livewire/Concerns/HasCommentActions.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Kirschbaum\Commentions\Livewire\Concerns;
+
+use Filament\Actions\Action;
+use Kirschbaum\Commentions\Comment as CommentModel;
+use Kirschbaum\Commentions\Config;
+use Kirschbaum\Commentions\Livewire\Comment;
+
+/**
+ * Provides the built-in edit/delete Filament actions for a comment, and caches
+ * any host-registered custom actions so they remain resolvable across requests.
+ *
+ * @mixin Comment
+ */
+trait HasCommentActions
+{
+    /** @var array<Action>|null */
+    protected ?array $customActions = null;
+
+    /**
+     * Invoked by Filament's InteractsWithActions::cacheTraitActions() before
+     * mounted actions are resolved, so host-registered actions (including ones
+     * that open modals) stay resolvable on subsequent requests.
+     */
+    public function cacheHasCommentActions(): void
+    {
+        foreach ($this->getCustomActions() as $action) {
+            $this->cacheAction($action);
+        }
+    }
+
+    public function editAction(): Action
+    {
+        return Action::make('edit')
+            ->label(__('commentions::comments.edit'))
+            ->icon('heroicon-s-pencil-square')
+            ->iconButton()
+            ->size('xs')
+            ->color('gray')
+            ->visible(fn (): bool => $this->commentUserCan('update'))
+            ->action(fn () => $this->edit());
+    }
+
+    public function deleteAction(): Action
+    {
+        return Action::make('delete')
+            ->label(__('commentions::comments.delete'))
+            ->icon('heroicon-s-trash')
+            ->iconButton()
+            ->size('xs')
+            ->color('gray')
+            ->visible(fn (): bool => $this->commentUserCan('delete'))
+            ->requiresConfirmation()
+            ->modalHeading(__('commentions::comments.delete_comment_heading'))
+            ->modalDescription(__('commentions::comments.delete_comment_body'))
+            ->modalSubmitActionLabel(__('commentions::comments.delete'))
+            ->action(fn () => $this->delete());
+    }
+
+    /**
+     * Custom actions registered by the host application via
+     * Config::registerCommentActions(), rendered after edit/delete.
+     *
+     * @return array<Action>
+     */
+    public function getCustomActions(): array
+    {
+        if (! $this->comment instanceof CommentModel) {
+            return [];
+        }
+
+        return $this->customActions ??= Config::getCommentActions($this->comment);
+    }
+
+    protected function commentUserCan(string $ability): bool
+    {
+        return $this->comment instanceof CommentModel
+            && (bool) Config::resolveAuthenticatedUser()?->can($ability, $this->comment);
+    }
+}

--- a/tests/Filament/CommentCustomActionsTest.php
+++ b/tests/Filament/CommentCustomActionsTest.php
@@ -1,0 +1,90 @@
+<?php
+
+use Filament\Actions\Action;
+use Illuminate\Support\Facades\Auth;
+use Kirschbaum\Commentions\Comment as CommentModel;
+use Kirschbaum\Commentions\Config;
+use Kirschbaum\Commentions\Livewire\Comment as CommentComponent;
+use Kirschbaum\Commentions\RenderableComment;
+use Tests\Models\Post;
+use Tests\Models\User;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
+beforeEach(function () {
+    Config::resolveAuthenticatedUserUsing(fn () => Auth::user());
+    Config::flushCommentActions();
+});
+
+afterEach(function () {
+    Config::flushCommentActions();
+});
+
+test('custom comment actions registered via Config are rendered', function () {
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $post = Post::factory()->create();
+    $comment = CommentModel::factory()->author($user)->commentable($post)->create();
+
+    Config::registerCommentActions(fn (CommentModel $comment) => Action::make('logs')
+        ->label('Activity Logs')
+        ->icon('heroicon-s-clock'));
+
+    livewire(CommentComponent::class, ['comment' => $comment])
+        ->assertActionVisible('logs')
+        ->assertSee('Activity Logs');
+});
+
+test('custom comment actions can be called', function () {
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $post = Post::factory()->create();
+    $comment = CommentModel::factory()->author($user)->commentable($post)->create();
+
+    Config::registerCommentActions(fn (CommentModel $comment) => Action::make('ping')
+        ->action(fn () => $comment->update(['body' => 'pinged'])));
+
+    livewire(CommentComponent::class, ['comment' => $comment])
+        ->callAction('ping');
+
+    expect($comment->fresh()->body)->toBe('pinged');
+});
+
+test('custom comment action callbacks receive the comment instance', function () {
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $post = Post::factory()->create();
+    $comment = CommentModel::factory()->author($user)->commentable($post)->create();
+
+    $received = null;
+
+    Config::registerCommentActions(function (CommentModel $resolved) use (&$received) {
+        $received = $resolved;
+
+        return Action::make('noop');
+    });
+
+    livewire(CommentComponent::class, ['comment' => $comment]);
+
+    expect($received)->not->toBeNull()
+        ->and($received->is($comment))->toBeTrue();
+});
+
+test('custom comment actions are not rendered for non-comment renderables', function () {
+    $user = User::factory()->create();
+    actingAs($user);
+
+    Config::registerCommentActions(fn (CommentModel $comment) => Action::make('logs')->label('Activity Logs'));
+
+    livewire(CommentComponent::class, [
+        'comment' => new RenderableComment(
+            id: 1,
+            authorName: 'System',
+            body: 'System notification',
+        ),
+    ])->assertActionDoesNotExist('logs');
+});

--- a/tests/Livewire/CommentTest.php
+++ b/tests/Livewire/CommentTest.php
@@ -29,8 +29,8 @@ test('can render a comment', function () {
     ])
         ->assertSee('Test comment body')
         ->assertSee($comment->author->name)
-        ->assertSeeHtml('wire:click="edit"')  // Author should see an edit button
-        ->assertSeeHtml('wire:click="delete"'); // Author should see a delete button
+        ->assertActionVisible('edit')  // Author should see an edit action
+        ->assertActionVisible('delete'); // Author should see a delete action
 });
 
 test('other users cannot see edit and delete buttons by default', function () {
@@ -44,8 +44,8 @@ test('other users cannot see edit and delete buttons by default', function () {
     livewire(CommentComponent::class, [
         'comment' => $comment,
     ])
-        ->assertDontSeeHtml('wire:click="edit"')
-        ->assertDontSeeHtml('wire:click="delete"');
+        ->assertActionHidden('edit')
+        ->assertActionHidden('delete');
 });
 
 test('guests cannot see edit and delete buttons', function () {
@@ -56,8 +56,8 @@ test('guests cannot see edit and delete buttons', function () {
     livewire(CommentComponent::class, [
         'comment' => $comment,
     ])
-        ->assertDontSeeHtml('wire:click="edit"')
-        ->assertDontSeeHtml('wire:click="delete"');
+        ->assertActionHidden('edit')
+        ->assertActionHidden('delete');
 });
 
 test('custom policy can change who can see edit and delete buttons', function () {
@@ -72,8 +72,8 @@ test('custom policy can change who can see edit and delete buttons', function ()
     livewire(CommentComponent::class, [
         'comment' => $comment,
     ])
-        ->assertDontSeeHtml('wire:click="edit"')
-        ->assertDontSeeHtml('wire:click="delete"');
+        ->assertActionHidden('edit')
+        ->assertActionHidden('delete');
 });
 
 test('author can update a comment by default', function () {
@@ -271,6 +271,41 @@ test('can render a custom renderable comment', function () {
     ])
         ->assertSee('System notification')
         ->assertSee('System')
-        ->assertDontSeeHtml('wire:click="edit"')  // Should not show edit button
-        ->assertDontSeeHtml('wire:click="delete"'); // Should not show delete button
+        ->assertActionHidden('edit')  // Should not show edit action
+        ->assertActionHidden('delete'); // Should not show delete action
+});
+
+test('the edit action enters edit mode', function () {
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $post = Post::factory()->create();
+    $comment = CommentModel::factory()->author($user)->commentable($post)->create([
+        'body' => 'Test comment body',
+    ]);
+
+    livewire(CommentComponent::class, [
+        'comment' => $comment,
+    ])
+        ->assertSet('editing', false)
+        ->callAction('edit')
+        ->assertSet('editing', true);
+});
+
+test('the delete action removes the comment', function () {
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $post = Post::factory()->create();
+    $comment = CommentModel::factory()->author($user)->commentable($post)->create();
+
+    livewire(CommentComponent::class, [
+        'comment' => $comment,
+    ])
+        ->callAction('delete')
+        ->assertDispatched('comment:deleted');
+
+    test()->assertDatabaseMissing('comments', [
+        'id' => $comment->id,
+    ]);
 });


### PR DESCRIPTION
Closes #25

### Summary

This PR replaces the hand-rolled comment controls (an edit icon-button wired to `wire:click="edit"` and a bespoke delete confirmation modal) with first-class Filament `Action` objects on the `Comment` Livewire component. It also adds an extension point so host applications can attach their own actions to each comment.

### Changes

- **Filament actions for edit/delete.** Introduces a `HasCommentActions` concern providing `editAction()` and `deleteAction()`. The delete action uses Filament's `requiresConfirmation()` instead of a custom modal. Visibility is gated by the existing `update`/`delete` policy checks, preserving current permission behavior.
- **`Comment` component now implements `HasActions`/`HasSchemas`,** pulling in `InteractsWithActions`, `InteractsWithSchemas`, and `ResolvesDynamicLivewireProperties`.
- **Custom actions extension point.** Host apps can register additional actions via `Config::registerCommentActions(fn (Comment $comment) => ...)`, returning a single `Action` or an array. These render after the built-in edit/delete controls. Registered actions are cached through Filament's `cacheTraitActions()` hook (`cacheHasCommentActions()`) so that modal-opening actions stay resolvable across Livewire requests.
- **Backward compatibility.** The legacy `delete()` and `edit()` Livewire methods are retained; the new actions delegate to them.
- **i18n.** Adds an `edit` translation key across all bundled locales (ar, en, es, fr, nl, ro).

### Usage

```php
use Kirschbaum\Commentions\Config;
use Filament\Actions\Action;

Config::registerCommentActions(fn ($comment) => Action::make('activityLogs')
    ->icon('heroicon-s-clock')
    ->iconButton()
    ->modalContent(/* ... */)
);
```

### Tests

- Adds `tests/Filament/CommentCustomActionsTest.php` covering custom action registration, rendering, and the modal-caching behavior.
- Extends `tests/Livewire/CommentTest.php` to exercise the new edit/delete actions and their permission gating.
- `tests/TestCase.php` flushes registered comment actions between tests via `Config::flushCommentActions()`.