### PR TITLE
fix: Update hasMore method to use overridable getComments method (#106)

### DIFF
--- a/src/Livewire/Concerns/HasPagination.php
+++ b/src/Livewire/Concerns/HasPagination.php
@@ -35,7 +35,7 @@ trait HasPagination
             return false;
         }
 
-        return $this->record->comments()->count() > $this->perPage;
+        return $this->record->getComments()->count() > $this->perPage;
     }
 
     public function getLoadMoreLabel(): string

--- a/tests/Concerns/HasPaginationTest.php
+++ b/tests/Concerns/HasPaginationTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Livewire\Concerns;
+
+use Kirschbaum\Commentions\Comment as CommentModel;
+use Kirschbaum\Commentions\Livewire\Concerns\HasPagination;
+use Kirschbaum\Commentions\RenderableComment;
+use Mockery;
+use Tests\Models\Post;
+use Tests\Models\User;
+
+it('returns true when using getComments vs comments in hasMore', function () {
+    /** @var User $user */
+    $user = User::factory()->create();
+    /** @var Post $realPost */
+    $realPost = Post::factory()->create();
+
+    /** @var CommentModel $comment */
+    $comment = CommentModel::factory()
+        ->author($user)
+        ->commentable($realPost)
+        ->create([
+            'body' => 'Real comment body',
+        ]);
+
+    $items = collect([
+        new RenderableComment(id: 1, authorName: 'System', body: 'System notice 1'),
+        new RenderableComment(id: 2, authorName: 'Bot', body: 'Automated message'),
+        new RenderableComment(id: 3, authorName: 'Bot', body: 'Automated message 2'),
+        new RenderableComment(id: 4, authorName: 'Bot', body: 'Automated message 2'),
+        new RenderableComment(id: 5, authorName: 'Bot', body: 'Automated message 4'),
+    ]);
+
+    $record = Mockery::mock();
+    $record->shouldReceive('comments')->never()->andReturn($comment);
+    $record->shouldReceive('getComments')->once()->andReturn($items->merge([$comment]));
+
+    $component = new class
+    {
+        use HasPagination;
+
+        public bool $paginate = true;
+
+        public $record;
+    };
+
+    $component->record = $record;
+
+    expect($component->hasMore())->toBeTrue();
+});

--- a/tests/Livewire/CommentListTest.php
+++ b/tests/Livewire/CommentListTest.php
@@ -40,7 +40,7 @@ test('CommentList calls getComments when paginating', function () {
     $post = Mockery::mock(Post::class)->makePartial();
 
     $post->shouldReceive('getComments')
-        ->once()
+        ->twice()
         ->andReturn(collect());
 
     $component = livewire(CommentList::class, [


### PR DESCRIPTION
Closes #106

### Summary

The **HasPagination** trait was checking if there were more `comments` on the record, but `getComments` can be overwritten on the record to add non-comments. The pagination (show more) would stop before showing all merged comment and non-comment entries.

### What changed

- **hasMore** method checks `getComments` instead of `comments`.

### Testing

Added to the Model where **Commentable**  was implemented:
```php
public function getComments(?int $limit = null): Collection
{
    $nonComment = collect([100, 150, 200, 300, 350, 500, 600, 700, 800])
        ->map(fn ($nonComment) => new RenderableComment(
            id: $nonComment,
            authorName: 'John Doe' . $nonComment,
            body: sprintf('Status changed from %s to %s', 'one', 'two') . $nonComment,
            createdAt: now()->addSeconds($nonComment),
            authorAvatar: null,
        ));
    
    $comments = $this->comments()->latest()->with('author')->get();

    $mergedCollection = $nonComment->merge($comments);
    if ($limit) {
        return $mergedCollection->take($limit);
    }

    return $mergedCollection;
}
```

On a View page and Infolist: if you don't have any comments, it might hide "Show More" right away. Sometimes switching between the View and the modal can show a different count if it appears to show all comments the first time.

Model resource Infolist:
```php
public static function configure(Schema $schema): Schema
{
        return $schema
            ->components([
                CommentsEntry::make('comments')
           ]);
}
```
Model resource View:
```php
protected function getHeaderActions(): array
{
    return [
        CommentsAction::make()
    ];
}
```