### PR TITLE
feat: Add record override, avatar and reaction toggles (#116)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ For Filament 4:
     ]),
 ```
 
+By default the entry uses the page's record. To comment on a different model (e.g. a pivot or a related record in a table modal), override it explicitly:
+
+```php
+CommentsEntry::make('comments')
+    ->record(fn () => $pivot)
+    ->mentionables(User::all());
+```
+
 2. Or in your table actions:
 
 If you are using Filament 3, you must use `CommentsTableAction` in your table's `actions` array:
@@ -491,9 +499,47 @@ By default, Commentions ships with the following reactions: `['👍', '❤️', 
 
 ```php
     'reactions' => [
+        'enabled' => env('COMMENTIONS_REACTIONS_ENABLED', true),
+
         'allowed' => ['👍', '❤️', '😂', '🎉', '👀'],
     ],
 ```
+
+Reactions are enabled by default. Disable them globally via `reactions.enabled`, or per component:
+
+```php
+CommentsEntry::make('comments')
+    ->mentionables(User::all())
+    ->disableReactions();
+
+CommentsAction::make()
+    ->mentionables(User::all())
+    ->disableReactions();
+```
+
+You can re-enable per component with `->enableReactions()` when disabled globally.
+
+#### Configuring Avatars
+
+Avatars are enabled by default. Disable them globally, or per component when you want comments flush to the left:
+
+```php
+    'avatars' => [
+        'enabled' => env('COMMENTIONS_AVATARS_ENABLED', true),
+    ],
+```
+
+```php
+CommentsEntry::make('comments')
+    ->mentionables(User::all())
+    ->disableAvatars();
+
+CommentsAction::make()
+    ->mentionables(User::all())
+    ->disableAvatars();
+```
+
+You can re-enable per component with `->enableAvatars()` when disabled globally.
 
 #### Configuring the Commenter avatar
 

--- a/config/commentions.php
+++ b/config/commentions.php
@@ -42,8 +42,14 @@ return [
     |--------------------------------------------------------------------------
     | Reactions
     |--------------------------------------------------------------------------
+    |
+    | Emoji reactions on comments. Enabled by default; disable globally here
+    | or per component with CommentsEntry::make()->disableReactions().
+    |
     */
     'reactions' => [
+        'enabled' => env('COMMENTIONS_REACTIONS_ENABLED', true),
+
         'allowed' => ['👍', '❤️', '😂', '😮', '😢', '🤔'],
     ],
 
@@ -84,6 +90,19 @@ return [
             ['bold', 'italic', 'underline'],
             ['bulletList', 'orderedList'],
         ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Avatars
+    |--------------------------------------------------------------------------
+    |
+    | Comment author avatars. Enabled by default; disable globally here
+    | or per component with CommentsEntry::make()->disableAvatars().
+    |
+    */
+    'avatars' => [
+        'enabled' => env('COMMENTIONS_AVATARS_ENABLED', true),
     ],
 
     /*

--- a/resources/views/comment-list.blade.php
+++ b/resources/views/comment-list.blade.php
@@ -24,6 +24,8 @@
             :ratings-enabled="$ratingsEnabled"
             :max-rating="$maxRating"
             :toolbar-buttons="$toolbarButtons"
+            :avatars-enabled="$avatarsEnabled ?? null"
+            :reactions-enabled="$reactionsEnabled ?? null"
             :readonly="$this->isReadonly()"
         />
     @endforeach

--- a/resources/views/comment.blade.php
+++ b/resources/views/comment.blade.php
@@ -7,14 +7,16 @@
     class="comm:flex comm:items-start comm:gap-x-4 comm:border comm:border-gray-300 comm:dark:border-gray-700 comm:p-4 comm:rounded-lg comm:shadow-sm comm:mb-2"
     id="filament-comment-{{ $comment->getId() }}"
 >
-    @if ($avatar = $comment->getAuthorAvatar())
-        <img
-            src="{{ $comment->getAuthorAvatar() }}"
-            alt="{{ __('commentions::comments.user_avatar_alt') }}"
-            class="comm:w-10 comm:h-10 comm:rounded-full comm:mt-0.5 comm:object-cover comm:object-center"
-        />
-    @else
-        <div class="comm:w-10 comm:h-10 comm:rounded-full comm:mt-0.5 "></div>
+    @if ($this->avatarsAreEnabled())
+        @if ($avatar = $comment->getAuthorAvatar())
+            <img
+                src="{{ $comment->getAuthorAvatar() }}"
+                alt="{{ __('commentions::comments.user_avatar_alt') }}"
+                class="comm:w-10 comm:h-10 comm:rounded-full comm:mt-0.5 comm:object-cover comm:object-center"
+            />
+        @else
+            <div class="comm:w-10 comm:h-10 comm:rounded-full comm:mt-0.5 "></div>
+        @endif
     @endif
 
     <div class="comm:flex-1 comm:min-w-0">
@@ -107,10 +109,11 @@
                 'comment' => $comment,
             ])
 
-            @if ($comment->isComment())
+            @if ($comment->isComment() && $this->reactionsAreEnabled())
                 <livewire:dynamic-component
                     :component="$commentionsComponentPrefix . 'reactions'"
                     :comment="$comment"
+                    :reactions-enabled="$this->reactionsAreEnabled()"
                     :readonly="$this->isReadonly()"
                     :wire:key="'reaction-manager-' . $comment->getId()"
                 />

--- a/resources/views/comments-modal.blade.php
+++ b/resources/views/comments-modal.blade.php
@@ -16,6 +16,8 @@
         :max-rating="$maxRating ?? null"
         :toolbar-buttons="$toolbarButtons ?? null"
         :attachments-enabled="$attachmentsEnabled ?? null"
+        :avatars-enabled="$avatarsEnabled ?? null"
+        :reactions-enabled="$reactionsEnabled ?? null"
         :readonly="$readonly ?? false"
     />
 </div>

--- a/resources/views/comments.blade.php
+++ b/resources/views/comments.blade.php
@@ -67,6 +67,8 @@
             :ratings-enabled="$this->ratingsAreEnabled()"
             :max-rating="$this->getMaxRating()"
             :toolbar-buttons="$toolbarButtons"
+            :avatars-enabled="$this->avatarsAreEnabled()"
+            :reactions-enabled="$this->reactionsAreEnabled()"
             :readonly="$this->isReadonly()"
         />
     </div>

--- a/resources/views/filament/infolists/components/comments-entry.blade.php
+++ b/resources/views/filament/infolists/components/comments-entry.blade.php
@@ -15,6 +15,8 @@
         :max-rating="$getMaxRating()"
         :toolbar-buttons="$getToolbarButtons()"
         :attachments-enabled="$attachmentsAreEnabled()"
+        :avatars-enabled="$avatarsAreEnabled()"
+        :reactions-enabled="$reactionsAreEnabled()"
         :readonly="$isReadonly()"
     />
 </x-dynamic-component>

--- a/src/Config.php
+++ b/src/Config.php
@@ -102,6 +102,16 @@ class Config
         return config('commentions.reactions.allowed', ['👍']);
     }
 
+    public static function reactionsAreEnabled(): bool
+    {
+        return (bool) config('commentions.reactions.enabled', true);
+    }
+
+    public static function avatarsAreEnabled(): bool
+    {
+        return (bool) config('commentions.avatars.enabled', true);
+    }
+
     public static function getAvatarProvider(): ?string
     {
         return config('commentions.avatar_provider');

--- a/src/Filament/Actions/CommentsAction.php
+++ b/src/Filament/Actions/CommentsAction.php
@@ -5,10 +5,12 @@ namespace Kirschbaum\Commentions\Filament\Actions;
 use Filament\Actions\Action;
 use Illuminate\Database\Eloquent\Model;
 use Kirschbaum\Commentions\Filament\Concerns\HasAttachments;
+use Kirschbaum\Commentions\Filament\Concerns\HasAvatars;
 use Kirschbaum\Commentions\Filament\Concerns\HasMentionables;
 use Kirschbaum\Commentions\Filament\Concerns\HasPagination;
 use Kirschbaum\Commentions\Filament\Concerns\HasPolling;
 use Kirschbaum\Commentions\Filament\Concerns\HasRatings;
+use Kirschbaum\Commentions\Filament\Concerns\HasReactions;
 use Kirschbaum\Commentions\Filament\Concerns\HasSidebar;
 use Kirschbaum\Commentions\Filament\Concerns\HasTipTapCssClasses;
 use Kirschbaum\Commentions\Filament\Concerns\HasToolbar;
@@ -17,10 +19,12 @@ use Kirschbaum\Commentions\Filament\Concerns\IsReadonly;
 class CommentsAction extends Action
 {
     use HasAttachments;
+    use HasAvatars;
     use HasMentionables;
     use HasPagination;
     use HasPolling;
     use HasRatings;
+    use HasReactions;
     use HasSidebar;
     use HasTipTapCssClasses;
     use HasToolbar;
@@ -47,6 +51,8 @@ class CommentsAction extends Action
                 'maxRating' => $this->getMaxRating(),
                 'toolbarButtons' => $this->getToolbarButtons(),
                 'attachmentsEnabled' => $this->attachmentsAreEnabled(),
+                'avatarsEnabled' => $this->avatarsAreEnabled(),
+                'reactionsEnabled' => $this->reactionsAreEnabled(),
                 'readonly' => $this->readonly,
             ]))
             ->modalWidth(fn () => $this->isSidebarEnabled() ? '4xl' : 'xl')

--- a/src/Filament/Actions/CommentsTableAction.php
+++ b/src/Filament/Actions/CommentsTableAction.php
@@ -4,9 +4,11 @@ namespace Kirschbaum\Commentions\Filament\Actions;
 
 use Illuminate\Database\Eloquent\Model;
 use Kirschbaum\Commentions\Filament\Concerns\HasAttachments;
+use Kirschbaum\Commentions\Filament\Concerns\HasAvatars;
 use Kirschbaum\Commentions\Filament\Concerns\HasMentionables;
 use Kirschbaum\Commentions\Filament\Concerns\HasPolling;
 use Kirschbaum\Commentions\Filament\Concerns\HasRatings;
+use Kirschbaum\Commentions\Filament\Concerns\HasReactions;
 use Kirschbaum\Commentions\Filament\Concerns\HasSidebar;
 use Kirschbaum\Commentions\Filament\Concerns\HasTipTapCssClasses;
 use Kirschbaum\Commentions\Filament\Concerns\HasToolbar;
@@ -22,9 +24,11 @@ use Kirschbaum\Commentions\Filament\Concerns\IsReadonly;
 class CommentsTableAction extends TableAction
 {
     use HasAttachments;
+    use HasAvatars;
     use HasMentionables;
     use HasPolling;
     use HasRatings;
+    use HasReactions;
     use HasSidebar;
     use HasTipTapCssClasses;
     use HasToolbar;
@@ -47,6 +51,8 @@ class CommentsTableAction extends TableAction
                 'maxRating' => $this->getMaxRating(),
                 'toolbarButtons' => $this->getToolbarButtons(),
                 'attachmentsEnabled' => $this->attachmentsAreEnabled(),
+                'avatarsEnabled' => $this->avatarsAreEnabled(),
+                'reactionsEnabled' => $this->reactionsAreEnabled(),
                 'readonly' => $this->readonly,
             ]))
             ->modalWidth(fn () => $this->isSidebarEnabled() ? '4xl' : 'xl')

--- a/src/Filament/Concerns/HasAvatars.php
+++ b/src/Filament/Concerns/HasAvatars.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Kirschbaum\Commentions\Filament\Concerns;
+
+use Closure;
+use Kirschbaum\Commentions\Config;
+
+trait HasAvatars
+{
+    protected bool|Closure|null $avatarsEnabled = null;
+
+    public function enableAvatars(bool|Closure $condition = true): static
+    {
+        $this->avatarsEnabled = $condition;
+
+        return $this;
+    }
+
+    public function disableAvatars(): static
+    {
+        $this->avatarsEnabled = false;
+
+        return $this;
+    }
+
+    public function avatarsAreEnabled(): bool
+    {
+        $value = $this->evaluate($this->avatarsEnabled);
+
+        return $value ?? Config::avatarsAreEnabled();
+    }
+}

--- a/src/Filament/Concerns/HasReactions.php
+++ b/src/Filament/Concerns/HasReactions.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Kirschbaum\Commentions\Filament\Concerns;
+
+use Closure;
+use Kirschbaum\Commentions\Config;
+
+trait HasReactions
+{
+    protected bool|Closure|null $reactionsEnabled = null;
+
+    public function enableReactions(bool|Closure $condition = true): static
+    {
+        $this->reactionsEnabled = $condition;
+
+        return $this;
+    }
+
+    public function disableReactions(): static
+    {
+        $this->reactionsEnabled = false;
+
+        return $this;
+    }
+
+    public function reactionsAreEnabled(): bool
+    {
+        $value = $this->evaluate($this->reactionsEnabled);
+
+        return $value ?? Config::reactionsAreEnabled();
+    }
+}

--- a/src/Filament/Infolists/Components/CommentsEntry.php
+++ b/src/Filament/Infolists/Components/CommentsEntry.php
@@ -2,12 +2,16 @@
 
 namespace Kirschbaum\Commentions\Filament\Infolists\Components;
 
+use Closure;
 use Filament\Infolists\Components\Entry;
+use Illuminate\Database\Eloquent\Model;
 use Kirschbaum\Commentions\Filament\Concerns\HasAttachments;
+use Kirschbaum\Commentions\Filament\Concerns\HasAvatars;
 use Kirschbaum\Commentions\Filament\Concerns\HasMentionables;
 use Kirschbaum\Commentions\Filament\Concerns\HasPagination;
 use Kirschbaum\Commentions\Filament\Concerns\HasPolling;
 use Kirschbaum\Commentions\Filament\Concerns\HasRatings;
+use Kirschbaum\Commentions\Filament\Concerns\HasReactions;
 use Kirschbaum\Commentions\Filament\Concerns\HasSidebar;
 use Kirschbaum\Commentions\Filament\Concerns\HasTipTapCssClasses;
 use Kirschbaum\Commentions\Filament\Concerns\HasToolbar;
@@ -16,14 +20,34 @@ use Kirschbaum\Commentions\Filament\Concerns\IsReadonly;
 class CommentsEntry extends Entry
 {
     use HasAttachments;
+    use HasAvatars;
     use HasMentionables;
     use HasPagination;
     use HasPolling;
     use HasRatings;
+    use HasReactions;
     use HasSidebar;
     use HasTipTapCssClasses;
     use HasToolbar;
     use IsReadonly;
 
     protected string $view = 'commentions::filament.infolists.components.comments-entry';
+
+    /**
+     * Override the record used for comments, independent from the page's record.
+     *
+     * Useful when rendering comments inside a table modal or any context where
+     * the target commentable differs from the container record (e.g. a pivot).
+     *
+     * Proxies to the underlying Filament model/record handling so getRecord()
+     * (used by the entry blade view) resolves to the given record.
+     *
+     * @param  Model|array<string, mixed>|Closure|null  $record
+     */
+    public function record(Model|array|Closure|null $record): static
+    {
+        $this->model($record);
+
+        return $this;
+    }
 }

--- a/src/Livewire/Comment.php
+++ b/src/Livewire/Comment.php
@@ -10,9 +10,11 @@ use Illuminate\Contracts\View\View;
 use Kirschbaum\Commentions\Comment as CommentModel;
 use Kirschbaum\Commentions\Config;
 use Kirschbaum\Commentions\Contracts\RenderableComment;
+use Kirschbaum\Commentions\Livewire\Concerns\HasAvatars;
 use Kirschbaum\Commentions\Livewire\Concerns\HasCommentActions;
 use Kirschbaum\Commentions\Livewire\Concerns\HasMentions;
 use Kirschbaum\Commentions\Livewire\Concerns\HasRatings;
+use Kirschbaum\Commentions\Livewire\Concerns\HasReactions;
 use Kirschbaum\Commentions\Livewire\Concerns\HasToolbarButtons;
 use Kirschbaum\Commentions\Livewire\Concerns\InteractsWithCommentSchemas;
 use Kirschbaum\Commentions\Livewire\Concerns\InteractsWithCommentSchemasBridge;
@@ -23,9 +25,11 @@ use Livewire\Component;
 
 class Comment extends Component implements HasActions, HasForms
 {
+    use HasAvatars;
     use HasCommentActions;
     use HasMentions;
     use HasRatings;
+    use HasReactions;
     use HasToolbarButtons;
     use InteractsWithActions;
     use InteractsWithCommentSchemas;
@@ -137,6 +141,10 @@ class Comment extends Component implements HasActions, HasForms
     #[Renderless]
     public function toggleReaction(string $reaction): void
     {
+        if ($this->isReadonly() || ! $this->reactionsAreEnabled()) {
+            return;
+        }
+
         if (! $this->comment instanceof CommentModel) {
             return;
         }

--- a/src/Livewire/CommentList.php
+++ b/src/Livewire/CommentList.php
@@ -4,10 +4,12 @@ namespace Kirschbaum\Commentions\Livewire;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
+use Kirschbaum\Commentions\Livewire\Concerns\HasAvatars;
 use Kirschbaum\Commentions\Livewire\Concerns\HasMentions;
 use Kirschbaum\Commentions\Livewire\Concerns\HasPagination;
 use Kirschbaum\Commentions\Livewire\Concerns\HasPolling;
 use Kirschbaum\Commentions\Livewire\Concerns\HasRatings;
+use Kirschbaum\Commentions\Livewire\Concerns\HasReactions;
 use Kirschbaum\Commentions\Livewire\Concerns\HasToolbarButtons;
 use Kirschbaum\Commentions\Livewire\Concerns\IsReadonly;
 use Livewire\Attributes\Computed;
@@ -16,10 +18,12 @@ use Livewire\Component;
 
 class CommentList extends Component
 {
+    use HasAvatars;
     use HasMentions;
     use HasPagination;
     use HasPolling;
     use HasRatings;
+    use HasReactions;
     use HasToolbarButtons;
     use IsReadonly;
 

--- a/src/Livewire/Comments.php
+++ b/src/Livewire/Comments.php
@@ -6,10 +6,12 @@ use Illuminate\Database\Eloquent\Model;
 use Kirschbaum\Commentions\Actions\SaveComment;
 use Kirschbaum\Commentions\Actions\StoreCommentAttachments;
 use Kirschbaum\Commentions\Config;
+use Kirschbaum\Commentions\Livewire\Concerns\HasAvatars;
 use Kirschbaum\Commentions\Livewire\Concerns\HasMentions;
 use Kirschbaum\Commentions\Livewire\Concerns\HasPagination;
 use Kirschbaum\Commentions\Livewire\Concerns\HasPolling;
 use Kirschbaum\Commentions\Livewire\Concerns\HasRatings;
+use Kirschbaum\Commentions\Livewire\Concerns\HasReactions;
 use Kirschbaum\Commentions\Livewire\Concerns\HasSidebar;
 use Kirschbaum\Commentions\Livewire\Concerns\HasToolbarButtons;
 use Kirschbaum\Commentions\Livewire\Concerns\IsReadonly;
@@ -21,10 +23,12 @@ use Livewire\WithFileUploads;
 
 class Comments extends Component
 {
+    use HasAvatars;
     use HasMentions;
     use HasPagination;
     use HasPolling;
     use HasRatings;
+    use HasReactions;
     use HasSidebar;
     use HasToolbarButtons;
     use IsReadonly;

--- a/src/Livewire/Concerns/HasAvatars.php
+++ b/src/Livewire/Concerns/HasAvatars.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Kirschbaum\Commentions\Livewire\Concerns;
+
+use Kirschbaum\Commentions\Config;
+
+trait HasAvatars
+{
+    public ?bool $avatarsEnabled = null;
+
+    public function avatarsAreEnabled(): bool
+    {
+        return $this->avatarsEnabled ?? Config::avatarsAreEnabled();
+    }
+}

--- a/src/Livewire/Concerns/HasReactions.php
+++ b/src/Livewire/Concerns/HasReactions.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Kirschbaum\Commentions\Livewire\Concerns;
+
+use Kirschbaum\Commentions\Config;
+
+trait HasReactions
+{
+    public ?bool $reactionsEnabled = null;
+
+    public function reactionsAreEnabled(): bool
+    {
+        return $this->reactionsEnabled ?? Config::reactionsAreEnabled();
+    }
+}

--- a/src/Livewire/Reactions.php
+++ b/src/Livewire/Reactions.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\View\View;
 use Kirschbaum\Commentions\Comment as CommentModel;
 use Kirschbaum\Commentions\Config;
 use Kirschbaum\Commentions\Contracts\RenderableComment;
+use Kirschbaum\Commentions\Livewire\Concerns\HasReactions;
 use Kirschbaum\Commentions\Livewire\Concerns\IsReadonly;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\On;
@@ -13,13 +14,14 @@ use Livewire\Component;
 
 class Reactions extends Component
 {
+    use HasReactions;
     use IsReadonly;
 
     public RenderableComment $comment;
 
     public function handleReactionToggle(string $reaction): void
     {
-        if ($this->isReadonly()) {
+        if ($this->isReadonly() || ! $this->reactionsAreEnabled()) {
             return;
         }
 

--- a/tests/Livewire/CommentAvatarsReactionsTest.php
+++ b/tests/Livewire/CommentAvatarsReactionsTest.php
@@ -1,0 +1,155 @@
+<?php
+
+use Illuminate\Support\Facades\Auth;
+use Kirschbaum\Commentions\Config;
+use Kirschbaum\Commentions\Filament\Actions\CommentsAction;
+use Kirschbaum\Commentions\Filament\Actions\CommentsTableAction;
+use Kirschbaum\Commentions\Filament\Infolists\Components\CommentsEntry;
+use Kirschbaum\Commentions\Livewire\Comment as CommentComponent;
+use Kirschbaum\Commentions\Livewire\Comments;
+use Tests\Models\Post;
+use Tests\Models\User;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
+beforeEach(function () {
+    Config::resolveAuthenticatedUserUsing(fn () => Auth::user());
+});
+
+test('CommentsEntry record overrides the container record', function () {
+    $pagePost = Post::factory()->create();
+    $pivotPost = Post::factory()->create();
+
+    $entry = CommentsEntry::make('comments')->record($pivotPost);
+
+    // Explicit record wins without needing a container.
+    expect($entry->getRecord(false))->toBe($pivotPost);
+
+    // Also resolves via getRecord() when a container exists is covered by
+    // the infolist harness in CommentsEntryTest; here we assert the override
+    // is stored and returned.
+    expect($entry->getRecord(false)->is($pivotPost))->toBeTrue()
+        ->and($entry->getRecord(false)->is($pagePost))->toBeFalse();
+});
+
+test('CommentsEntry record accepts a closure', function () {
+    $post = Post::factory()->create();
+
+    $entry = CommentsEntry::make('comments')->record(fn () => $post);
+
+    expect($entry->getRecord(false)->is($post))->toBeTrue();
+});
+
+test('avatars render by default and can be disabled per component', function () {
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $post = Post::factory()->create();
+    $comment = Kirschbaum\Commentions\Comment::factory()->author($user)->commentable($post)->create([
+        'body' => 'Avatar test',
+    ]);
+
+    livewire(CommentComponent::class, ['comment' => $comment])
+        ->assertSee('User Avatar', false);
+
+    livewire(CommentComponent::class, ['comment' => $comment, 'avatarsEnabled' => false])
+        ->assertDontSee('User Avatar', false);
+
+    livewire(Comments::class, ['record' => $post, 'avatarsEnabled' => false])
+        ->assertDontSee('User Avatar', false);
+});
+
+test('avatars can be disabled globally via config', function () {
+    config()->set('commentions.avatars.enabled', false);
+
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $post = Post::factory()->create();
+    $comment = Kirschbaum\Commentions\Comment::factory()->author($user)->commentable($post)->create([
+        'body' => 'Avatar config test',
+    ]);
+
+    livewire(CommentComponent::class, ['comment' => $comment])
+        ->assertDontSee('User Avatar', false);
+
+    expect(Config::avatarsAreEnabled())->toBeFalse();
+});
+
+test('CommentsEntry, CommentsAction and CommentsTableAction support avatar configuration', function () {
+    expect(CommentsEntry::make('comments')->avatarsAreEnabled())->toBeTrue()
+        ->and(CommentsEntry::make('comments')->disableAvatars()->avatarsAreEnabled())->toBeFalse()
+        ->and(CommentsEntry::make('comments')->enableAvatars(false)->avatarsAreEnabled())->toBeFalse()
+        ->and(CommentsAction::make()->disableAvatars()->avatarsAreEnabled())->toBeFalse()
+        ->and(CommentsTableAction::make()->disableAvatars()->avatarsAreEnabled())->toBeFalse();
+
+    config()->set('commentions.avatars.enabled', false);
+
+    expect(CommentsEntry::make('comments')->avatarsAreEnabled())->toBeFalse()
+        ->and(CommentsEntry::make('comments')->enableAvatars()->avatarsAreEnabled())->toBeTrue();
+});
+
+test('reactions render by default and can be disabled per component', function () {
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $post = Post::factory()->create();
+    $comment = Kirschbaum\Commentions\Comment::factory()->author($user)->commentable($post)->create([
+        'body' => 'Reaction test',
+    ]);
+
+    livewire(CommentComponent::class, ['comment' => $comment])
+        ->assertSee('Add Reaction', false);
+
+    livewire(CommentComponent::class, ['comment' => $comment, 'reactionsEnabled' => false])
+        ->assertDontSee('Add Reaction', false);
+
+    livewire(Comments::class, ['record' => $post, 'reactionsEnabled' => false])
+        ->assertDontSee('Add Reaction', false);
+});
+
+test('reactions can be disabled globally via config', function () {
+    config()->set('commentions.reactions.enabled', false);
+
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $post = Post::factory()->create();
+    $comment = Kirschbaum\Commentions\Comment::factory()->author($user)->commentable($post)->create([
+        'body' => 'Reaction config test',
+    ]);
+
+    livewire(CommentComponent::class, ['comment' => $comment])
+        ->assertDontSee('Add Reaction', false);
+
+    expect(Config::reactionsAreEnabled())->toBeFalse();
+});
+
+test('CommentsEntry, CommentsAction and CommentsTableAction support reaction configuration', function () {
+    expect(CommentsEntry::make('comments')->reactionsAreEnabled())->toBeTrue()
+        ->and(CommentsEntry::make('comments')->disableReactions()->reactionsAreEnabled())->toBeFalse()
+        ->and(CommentsEntry::make('comments')->enableReactions(false)->reactionsAreEnabled())->toBeFalse()
+        ->and(CommentsAction::make()->disableReactions()->reactionsAreEnabled())->toBeFalse()
+        ->and(CommentsTableAction::make()->disableReactions()->reactionsAreEnabled())->toBeFalse();
+
+    config()->set('commentions.reactions.enabled', false);
+
+    expect(CommentsEntry::make('comments')->reactionsAreEnabled())->toBeFalse()
+        ->and(CommentsEntry::make('comments')->enableReactions()->reactionsAreEnabled())->toBeTrue();
+});
+
+test('toggling a reaction is ignored when reactions are disabled', function () {
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $post = Post::factory()->create();
+    $comment = Kirschbaum\Commentions\Comment::factory()->author($user)->commentable($post)->create();
+
+    livewire(CommentComponent::class, ['comment' => $comment, 'reactionsEnabled' => false])
+        ->call('toggleReaction', '👍');
+
+    test()->assertDatabaseMissing('comment_reactions', [
+        'comment_id' => $comment->id,
+    ]);
+});

--- a/tests/Livewire/CommentAvatarsReactionsTest.php
+++ b/tests/Livewire/CommentAvatarsReactionsTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Auth;
+use Kirschbaum\Commentions\Comment;
 use Kirschbaum\Commentions\Config;
 use Kirschbaum\Commentions\Filament\Actions\CommentsAction;
 use Kirschbaum\Commentions\Filament\Actions\CommentsTableAction;
@@ -46,7 +47,7 @@ test('avatars render by default and can be disabled per component', function () 
     actingAs($user);
 
     $post = Post::factory()->create();
-    $comment = Kirschbaum\Commentions\Comment::factory()->author($user)->commentable($post)->create([
+    $comment = Comment::factory()->author($user)->commentable($post)->create([
         'body' => 'Avatar test',
     ]);
 
@@ -67,7 +68,7 @@ test('avatars can be disabled globally via config', function () {
     actingAs($user);
 
     $post = Post::factory()->create();
-    $comment = Kirschbaum\Commentions\Comment::factory()->author($user)->commentable($post)->create([
+    $comment = Comment::factory()->author($user)->commentable($post)->create([
         'body' => 'Avatar config test',
     ]);
 
@@ -95,7 +96,7 @@ test('reactions render by default and can be disabled per component', function (
     actingAs($user);
 
     $post = Post::factory()->create();
-    $comment = Kirschbaum\Commentions\Comment::factory()->author($user)->commentable($post)->create([
+    $comment = Comment::factory()->author($user)->commentable($post)->create([
         'body' => 'Reaction test',
     ]);
 
@@ -116,7 +117,7 @@ test('reactions can be disabled globally via config', function () {
     actingAs($user);
 
     $post = Post::factory()->create();
-    $comment = Kirschbaum\Commentions\Comment::factory()->author($user)->commentable($post)->create([
+    $comment = Comment::factory()->author($user)->commentable($post)->create([
         'body' => 'Reaction config test',
     ]);
 
@@ -144,7 +145,7 @@ test('toggling a reaction is ignored when reactions are disabled', function () {
     actingAs($user);
 
     $post = Post::factory()->create();
-    $comment = Kirschbaum\Commentions\Comment::factory()->author($user)->commentable($post)->create();
+    $comment = Comment::factory()->author($user)->commentable($post)->create();
 
     livewire(CommentComponent::class, ['comment' => $comment, 'reactionsEnabled' => false])
         ->call('toggleReaction', '👍');


### PR DESCRIPTION
Closes #116.

Adds:
- `CommentsEntry::record()` to comment on a different model than the page record (e.g. pivot in a table modal). Proxies to Filament model handling.
- Avatar toggle: `avatars.enabled` config + `enableAvatars()`/`disableAvatars()` on entry/actions, threaded through Livewire to hide avatar column.
- Reactions toggle: `reactions.enabled` config + `enableReactions()`/`disableReactions()`, gated in comment view with guards in `Comment::toggleReaction()` and `Reactions::handleReactionToggle()`.

Notes:
- Reactions view intentionally not wrapped in a conditional root (Livewire requires a stable root tag); gating lives in the parent.
- Tests: `tests/Livewire/CommentAvatarsReactionsTest.php` (9 tests). Full suite: 162 passed. `composer lint:check` passes; phpstan shows only the 7 pre-existing errors.