### PR TITLE
fix: Resolve author name via Manager and handle deleted authors

### DIFF
--- a/resources/lang/ar/comments.php
+++ b/resources/lang/ar/comments.php
@@ -7,6 +7,7 @@ return [
     'no_comments_yet' => 'لا توجد تعليقات .',
 
     'user_avatar_alt' => 'صورة المستخدم ',
+    'deleted_user' => 'مستخدم محذوف',
 
     'commented_at' => 'علق في :datetime',
     'edited_at' => 'تم التعديل في :datetime',

--- a/resources/lang/en/comments.php
+++ b/resources/lang/en/comments.php
@@ -7,6 +7,7 @@ return [
     'no_comments_yet' => 'No comments yet.',
 
     'user_avatar_alt' => 'User Avatar',
+    'deleted_user' => 'Deleted user',
 
     'commented_at' => 'Commented at :datetime',
     'edited_at' => 'Edited at :datetime',

--- a/resources/lang/es/comments.php
+++ b/resources/lang/es/comments.php
@@ -7,6 +7,7 @@ return [
     'no_comments_yet' => 'Aún no hay comentarios.',
 
     'user_avatar_alt' => 'Avatar de usuario',
+    'deleted_user' => 'Usuario eliminado',
 
     'commented_at' => 'Comentado el :datetime',
     'edited_at' => 'Editado el :datetime',

--- a/resources/lang/fr/comments.php
+++ b/resources/lang/fr/comments.php
@@ -7,6 +7,7 @@ return [
     'no_comments_yet' => 'Aucun commentaire pour le moment.',
 
     'user_avatar_alt' => 'Avatar de l\'utilisateur',
+    'deleted_user' => 'Utilisateur supprimé',
 
     'commented_at' => 'Commenté le :datetime',
     'edited_at' => 'Edité le :datetime',

--- a/resources/lang/nl/comments.php
+++ b/resources/lang/nl/comments.php
@@ -7,6 +7,7 @@ return [
     'no_comments_yet' => 'Nog geen opmerkingen.',
 
     'user_avatar_alt' => 'Profielfoto',
+    'deleted_user' => 'Verwijderde gebruiker',
 
     'commented_at' => 'Geplaatst op :datetime',
     'edited_at' => 'Bewerkt op :datetime',

--- a/resources/lang/ro/comments.php
+++ b/resources/lang/ro/comments.php
@@ -7,6 +7,7 @@ return [
     'no_comments_yet' => 'Niciun comentariu încă.',
 
     'user_avatar_alt' => 'Avatar',
+    'deleted_user' => 'Utilizator șters',
 
     'commented_at' => 'Adăugat la :datetime',
     'edited_at' => 'Editat la :datetime',

--- a/src/Comment.php
+++ b/src/Comment.php
@@ -30,7 +30,7 @@ use Kirschbaum\Commentions\Database\Factories\CommentFactory;
  * @property string $body_markdown
  * @property string $body_parsed
  * @property int $author_id
- * @property Model|Commenter $author
+ * @property Model|Commenter|null $author
  * @property Commentable $commentable
  * @property-read DateTime|Carbon $created_at
  * @property-read DateTime|Carbon $updated_at
@@ -131,7 +131,13 @@ class Comment extends Model implements RenderableComment
 
     public function getAuthorName(): string
     {
-        return $this->author->name;
+        if ($this->author === null) {
+            return __('commentions::comments.deleted_user');
+        }
+
+        $name = Manager::getName($this->author);
+
+        return filled($name) ? (string) $name : __('commentions::comments.deleted_user');
     }
 
     public function getAuthorAvatar(): string
@@ -144,13 +150,15 @@ class Comment extends Model implements RenderableComment
             }
         }
 
-        $providerAvatar = $this->resolveAvatarFromProvider();
+        if ($this->author !== null) {
+            $providerAvatar = $this->resolveAvatarFromProvider();
 
-        if (! is_null($providerAvatar)) {
-            return $providerAvatar;
+            if (! is_null($providerAvatar)) {
+                return $providerAvatar;
+            }
         }
 
-        $name = str(Manager::getName($this->author))
+        $name = str($this->getAuthorName())
             ->trim()
             ->explode(' ')
             ->map(fn (string $segment): string => filled($segment) ? mb_substr($segment, 0, 1) : '')

--- a/tests/CommentAuthorNameTest.php
+++ b/tests/CommentAuthorNameTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use Kirschbaum\Commentions\Comment as CommentModel;
+use Tests\Models\Post;
+use Tests\Models\User;
+use Tests\Models\UserWithCommenterName;
+use Tests\Models\UserWithFilamentName;
+
+test('getAuthorName uses the author name property by default', function () {
+    $user = User::factory()->create(['name' => 'Jane Doe']);
+    $post = Post::factory()->create();
+    $comment = CommentModel::factory()->author($user)->commentable($post)->create();
+
+    expect($comment->getAuthorName())->toBe('Jane Doe');
+});
+
+test('getAuthorName uses getCommenterName when the author defines it', function () {
+    $user = UserWithCommenterName::query()->find(
+        User::factory()->create(['name' => 'Jane Doe'])->id,
+    );
+    $post = Post::factory()->create();
+    $comment = CommentModel::factory()->author($user)->commentable($post)->create();
+
+    expect($comment->getAuthorName())->toBe('Commenter #' . $user->id)
+        ->and($comment->author->name)->toBe('Jane Doe');
+});
+
+test('getAuthorName uses Filament HasName when the author implements it', function () {
+    $user = UserWithFilamentName::query()->find(
+        User::factory()->create(['name' => 'Jane Doe'])->id,
+    );
+    $post = Post::factory()->create();
+    $comment = CommentModel::factory()->author($user)->commentable($post)->create();
+
+    expect($comment->getAuthorName())->toBe('Filament #' . $user->id)
+        ->and($comment->author->name)->toBe('Jane Doe');
+});
+
+test('getAuthorName falls back when the author has been deleted', function () {
+    $user = User::factory()->create();
+    $post = Post::factory()->create();
+    $comment = CommentModel::factory()->author($user)->commentable($post)->create();
+
+    $user->delete();
+    $comment->refresh();
+
+    expect($comment->author)->toBeNull()
+        ->and($comment->getAuthorName())->toBe(__('commentions::comments.deleted_user'));
+});
+
+test('getAuthorAvatar does not throw when the author has been deleted', function () {
+    $user = User::factory()->create();
+    $post = Post::factory()->create();
+    $comment = CommentModel::factory()->author($user)->commentable($post)->create();
+
+    $user->delete();
+    $comment->refresh();
+
+    expect($comment->getAuthorAvatar())
+        ->toStartWith('https://ui-avatars.com/api/?');
+});

--- a/tests/Livewire/CommentTest.php
+++ b/tests/Livewire/CommentTest.php
@@ -33,6 +33,26 @@ test('can render a comment', function () {
         ->assertActionVisible('delete'); // Author should see a delete action
 });
 
+test('can render a comment whose author was deleted', function () {
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $author = User::factory()->create();
+    $post = Post::factory()->create();
+    $comment = CommentModel::factory()->author($author)->commentable($post)->create([
+        'body' => 'Orphaned comment',
+    ]);
+
+    $author->delete();
+    $comment->refresh();
+
+    livewire(CommentComponent::class, [
+        'comment' => $comment,
+    ])
+        ->assertSee('Orphaned comment')
+        ->assertSee(__('commentions::comments.deleted_user'));
+});
+
 test('other users cannot see edit and delete buttons by default', function () {
     $user = User::factory()->create();
     actingAs($user);

--- a/tests/Models/UserWithCommenterName.php
+++ b/tests/Models/UserWithCommenterName.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Tests\Models;
+
+class UserWithCommenterName extends User
+{
+    protected $table = 'users';
+
+    public function getCommenterName(): string
+    {
+        return 'Commenter #' . $this->id;
+    }
+}

--- a/tests/Models/UserWithFilamentName.php
+++ b/tests/Models/UserWithFilamentName.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Tests\Models;
+
+use Filament\Models\Contracts\HasName;
+
+class UserWithFilamentName extends User implements HasName
+{
+    protected $table = 'users';
+
+    public function getFilamentName(): string
+    {
+        return 'Filament #' . $this->id;
+    }
+}


### PR DESCRIPTION
Closes #121.

## Problem

`Comment::getAuthorName()` read `$this->author->name` directly. That:

- fatals when the author has been deleted (`$this->author` is null)
- ignores the documented `getCommenterName()` / Filament `HasName` customizations, so the displayed name can disagree with mentions and avatars (which already go through `Manager::getName()`)

`getAuthorAvatar()` had the same null-author crash via `Manager::getName($this->author)`.

## Fix

- Resolve the display name through `Manager::getName()`, with a translated `deleted_user` fallback when the author is missing or unnamed
- Skip the avatar provider when there is no author, and generate initials from `getAuthorName()`

## Tests

- `tests/CommentAuthorNameTest.php`: default `name`, `getCommenterName()`, `HasName`, deleted author name + avatar
- Livewire render of a comment whose author was deleted

Full suite: 175 passed. Pint clean. PHPStan unchanged — the 7 pre-existing errors in `tests/Livewire/CommentReactionTest.php` are also present on `main`.