### PR TITLE
fix: Honor visible()/hidden() on comment actions and default size to xs

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,7 +575,7 @@ Any class exposing a `get(Model|Authenticatable $user): string` method works.
 
 Add additional actions next to edit/delete:
 
-```bash
+```php
 use Kirschbaum\Commentions\Config;
 use Filament\Actions\Action;
 
@@ -585,6 +585,8 @@ Config::registerCommentActions(fn ($comment) => Action::make('activityLogs')
     ->modalContent(/* ... */)
 );
 ```
+
+Custom actions default to `size('xs')` so they match the built-in edit/delete buttons. Override with `->size()` if needed. Use `visible()` / `hidden()` to show or hide an action; hidden actions are not rendered.
 
 #### Configuring Comment Ratings
 

--- a/resources/views/comment.blade.php
+++ b/resources/views/comment.blade.php
@@ -44,11 +44,10 @@
 
             @if (! $this->isReadonly() && $comment->isComment())
                 <div class="comm:flex comm:gap-x-1">
-                    {{ $this->editAction }}
-                    {{ $this->deleteAction }}
-
-                    @foreach ($this->getCustomActions() as $commentAction)
-                        {{ $commentAction }}
+                    @foreach ([$this->editAction, $this->deleteAction, ...$this->getCustomActions()] as $commentAction)
+                        @if ($commentAction->isVisible())
+                            {{ $commentAction }}
+                        @endif
                     @endforeach
                 </div>
             @endif

--- a/src/Livewire/Concerns/HasCommentActions.php
+++ b/src/Livewire/Concerns/HasCommentActions.php
@@ -73,7 +73,9 @@ trait HasCommentActions
             return [];
         }
 
-        return $this->customActions ??= Config::getCommentActions($this->comment);
+        return $this->customActions ??= collect(Config::getCommentActions($this->comment))
+            ->each(fn (Action $action) => $action->defaultSize('xs'))
+            ->all();
     }
 
     protected function commentUserCan(string $ability): bool

--- a/tests/Filament/CommentCustomActionsTest.php
+++ b/tests/Filament/CommentCustomActionsTest.php
@@ -88,3 +88,79 @@ test('custom comment actions are not rendered for non-comment renderables', func
         ),
     ])->assertActionDoesNotExist('logs');
 });
+
+test('hidden custom comment actions are not rendered in the html', function () {
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $post = Post::factory()->create();
+    $comment = CommentModel::factory()->author($user)->commentable($post)->create();
+
+    Config::registerCommentActions(fn (CommentModel $comment) => Action::make('deleteFiles')
+        ->label('Delete attached files')
+        ->visible(false));
+
+    livewire(CommentComponent::class, ['comment' => $comment])
+        ->assertActionHidden('deleteFiles')
+        ->assertDontSee('Delete attached files');
+});
+
+test('custom comment action visibility is evaluated against the comment', function () {
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $post = Post::factory()->create();
+    $comment = CommentModel::factory()->author($user)->commentable($post)->create();
+
+    Config::registerCommentActions(fn (CommentModel $comment) => Action::make('deleteFiles')
+        ->label('Delete attached files')
+        ->visible(fn (): bool => $comment->attachments()->exists()));
+
+    livewire(CommentComponent::class, ['comment' => $comment])
+        ->assertActionHidden('deleteFiles')
+        ->assertDontSee('Delete attached files');
+});
+
+test('visible custom comment actions are rendered in the html', function () {
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $post = Post::factory()->create();
+    $comment = CommentModel::factory()->author($user)->commentable($post)->create();
+
+    Config::registerCommentActions(fn (CommentModel $comment) => Action::make('deleteFiles')
+        ->label('Delete attached files')
+        ->visible(true));
+
+    livewire(CommentComponent::class, ['comment' => $comment])
+        ->assertActionVisible('deleteFiles')
+        ->assertSee('Delete attached files');
+});
+
+test('custom comment actions default to extra small size', function () {
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $post = Post::factory()->create();
+    $comment = CommentModel::factory()->author($user)->commentable($post)->create();
+
+    Config::registerCommentActions(fn (CommentModel $comment) => Action::make('logs'));
+
+    $component = livewire(CommentComponent::class, ['comment' => $comment]);
+
+    expect($component->instance()->getAction('logs')->getSize())->toBe('xs');
+});
+
+test('custom comment actions can override the default size', function () {
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $post = Post::factory()->create();
+    $comment = CommentModel::factory()->author($user)->commentable($post)->create();
+
+    Config::registerCommentActions(fn (CommentModel $comment) => Action::make('logs')->size('sm'));
+
+    $component = livewire(CommentComponent::class, ['comment' => $comment]);
+
+    expect($component->instance()->getAction('logs')->getSize())->toBe('sm');
+});

--- a/tests/Livewire/CommentTest.php
+++ b/tests/Livewire/CommentTest.php
@@ -45,7 +45,9 @@ test('other users cannot see edit and delete buttons by default', function () {
         'comment' => $comment,
     ])
         ->assertActionHidden('edit')
-        ->assertActionHidden('delete');
+        ->assertActionHidden('delete')
+        ->assertDontSee(__('commentions::comments.edit'))
+        ->assertDontSee(__('commentions::comments.delete'));
 });
 
 test('guests cannot see edit and delete buttons', function () {


### PR DESCRIPTION
Closes #120.

## Problem

Two issues with custom comment actions:

1. **`visible()` / `hidden()` disable instead of hide.** Filament's icon-button `toHtml()` does not skip hidden actions — it only checks `isDisabled()`, and `isDisabled()` returns true when the action is hidden. Rendering `{{ $action }}` therefore produced a disabled button. The same applied to edit/delete for users who cannot update/delete.

2. **Default size is larger than edit/delete.** Built-in actions set `size('xs')`. Custom actions used Filament's medium default unless the host set size explicitly.

## Fix

- Only render comment actions when `isVisible()` is true
- Apply `defaultSize('xs')` to custom actions so they match edit/delete unless the host overrides with `->size()`

## Tests

- Hidden custom actions are absent from the HTML (including `visible()` closures that inspect the comment)
- Visible custom actions still render
- Default size is `xs`; an explicit `size('sm')` is preserved
- Unauthorized edit/delete labels are not in the HTML

Full suite: 174 passed. Pint clean. PHPStan unchanged — the 7 pre-existing errors in `tests/Livewire/CommentReactionTest.php` are also present on `main`.