### PR TITLE
feat: Allow forcing a refresh of the comments list

### DIFF
--- a/README.md
+++ b/README.md
@@ -892,6 +892,23 @@ Infolists\Components\Section::make('Comments')
     ]),
 ```
 
+### Refreshing comments
+
+To reload the comments list immediately (for example after saving the record, so custom `getComments()` items such as activity-log entries appear without waiting for polling), dispatch the `commentions:refresh` Livewire event:
+
+```php
+protected function afterSave(): void
+{
+    $this->dispatch('commentions:refresh');
+}
+```
+
+Or from JavaScript:
+
+```js
+Livewire.dispatch('commentions:refresh')
+```
+
 ### Rendering non-Comments in the list
 
 Sometimes you might want to render non-Comments in the list of comments. For example, you might want to render when the status of a project is changed. For this, you can override the `getComments` method in your model, and return instances of the `Kirschbaum\Commentions\RenderableComment` data object.

--- a/src/Livewire/CommentList.php
+++ b/src/Livewire/CommentList.php
@@ -45,6 +45,7 @@ class CommentList extends Component
     #[On('comment:saved')]
     #[On('comment:updated')]
     #[On('comment:deleted')]
+    #[On('commentions:refresh')]
     public function reloadComments(): void
     {
         unset($this->comments);

--- a/src/Livewire/Comments.php
+++ b/src/Livewire/Comments.php
@@ -98,6 +98,12 @@ class Comments extends Component
         $this->dispatch('comment:saved');
     }
 
+    #[On('commentions:refresh')]
+    public function refreshComments(): void
+    {
+        $this->dispatch('comment:saved');
+    }
+
     public function render()
     {
         return view('commentions::comments');

--- a/tests/Livewire/CommentListTest.php
+++ b/tests/Livewire/CommentListTest.php
@@ -161,6 +161,31 @@ test('CommentList can render both Comment and RenderableComment items', function
         ->assertSee('System message');
 });
 
+test('CommentList reloads comments when commentions:refresh is dispatched', function () {
+    /** @var User $user */
+    $user = User::factory()->create();
+    /** @var Post $post */
+    $post = Post::factory()->create();
+
+    CommentModel::factory()->author($user)->commentable($post)->create([
+        'body' => 'Existing comment',
+    ]);
+
+    $component = livewire(CommentList::class, [
+        'record' => $post,
+        'paginate' => false,
+    ])->assertSee('Existing comment');
+
+    CommentModel::factory()->author($user)->commentable($post)->create([
+        'body' => 'Comment added after render',
+    ]);
+
+    $component
+        ->assertDontSee('Comment added after render')
+        ->dispatch('commentions:refresh')
+        ->assertSee('Comment added after render');
+});
+
 test('CommentList renders Comment and RenderableComment sharing an id without key collision', function () {
     /** @var User $user */
     $user = User::factory()->create();

--- a/tests/Livewire/CommentsTest.php
+++ b/tests/Livewire/CommentsTest.php
@@ -45,6 +45,20 @@ test('can create a comment', function () {
     });
 });
 
+test('Comments forwards commentions:refresh so the list reloads', function () {
+    /** @var User $user */
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $post = Post::factory()->create();
+
+    livewire(Comments::class, [
+        'record' => $post,
+    ])
+        ->dispatch('commentions:refresh')
+        ->assertDispatched('comment:saved');
+});
+
 test('comment creation requires body', function () {
     /** @var User $user */
     $user = User::factory()->create();


### PR DESCRIPTION
Closes #105.

## Problem

There was no way to reload `<livewire:commentions.comments>` immediately after saving the record. Custom `getComments()` items (e.g. activity-log status changes) only appeared after the next poll.

## Fix

Listen for a public `commentions:refresh` Livewire event:

- `CommentList` reloads its computed comments
- `Comments` forwards the event as `comment:saved` so targeting the parent component still refreshes the nested list

```php
protected function afterSave(): void
{
    $this->dispatch('commentions:refresh');
}
```

## Tests

- Comment list shows comments created after the initial render once `commentions:refresh` is dispatched
- Comments component forwards `commentions:refresh` as `comment:saved`

Full suite: 182 passed. Pint clean. PHPStan unchanged — the 7 pre-existing errors in `tests/Livewire/CommentReactionTest.php` are also present on `main`.